### PR TITLE
New Debian package URL

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,2 +1,2 @@
 ---
-gitlab_package_url: "https://downloads-packages.s3.amazonaws.com/ubuntu-12.04/gitlab_7.1.1-omnibus.1-1_amd64.deb"
+gitlab_package_url: "https://downloads-packages.s3.amazonaws.com/debian-7.7/gitlab_7.6.2-omnibus.5.3.0.ci.1-1_amd64.deb"


### PR DESCRIPTION
There is a Debian specific package to be used instead of the ubuntu version.  The ubuntu version gave me problems with libc-version.
