### PR TITLE
Add firewalld support for EL7.

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,3 +2,6 @@
 - name: restart gitlab
   command: gitlab-ctl reconfigure
   failed_when: false
+
+- name: reload firewalld
+  service: name=firewalld state=reloaded

--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -1,0 +1,9 @@
+---
+- name: Open HTTPS port
+  firewalld: service=https permanent=true state=enabled
+  notify: reload firewalld
+
+- name: Open HTTP port
+  firewalld: service=http permanent=true state=enabled
+  when: gitlab_redirect_http_to_https == 'true'
+  notify: reload firewalld

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,3 +81,8 @@
     dest=/etc/gitlab/gitlab.rb
     owner=root group=root mode=600
   notify: restart gitlab
+
+# RHEL 7+ only (for firewalld)
+- name: Process firewalld rules
+  include: firewalld.yml
+  when: (ansible_os_family == 'RedHat') and (ansible_distribution_major_version|int >= 7)


### PR DESCRIPTION
Out-of-the-box, EL 7 ships with ports 80 and 443 firewalled, but with Ansible's simple firewalld module it's trivial to enable them as needed within this role.
