### PR TITLE
Allow arbitrary gitlab_rails key/values in gitlab.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,22 @@ Whether to create a self-signed certificate for serving GitLab over a secure con
 
 GitLab LDAP configuration; if `gitlab_ldap_enabled` is `true`, the rest of the configuration will tell GitLab how to connect to an LDAP server for centralized authentication.
 
-Use a custom From email address. Defaults to `gitlab@example.com`
+Optional settings: use a custom **From** email address (default: `gitlab@example.com`) and keep backups for 7 days (`604800` seconds):
 
-    # Custom From email address.
-    gitlab_email_from: "git@example.com"
+    gitlab_rails:
+      gitlab_email_from: "git@example.com"
+      backup_keep_time: 604800
+
+The dictionary `gitlab_rails` adds its keys and their values to `gitlab.rb` in the form, sorted by key:
+
+    gitlab_rails['key'] = "value"
+
+The example dictionary above would result in the following being added to `gitlab.rb`:
+
+    gitlab_rails['gitlab_email_from'] = "git@example.com"
+    gitlab_rails['backup_keep_time'] = "604800"
+
+See: [gitlab.yml.md](https://gitlab.com/gitlab-org/omnibus-gitlab/blob/629def0a7a26e7c2326566f0758d4a27857b52a3/doc/settings/gitlab.yml.md) for more information.
 
 ## Dependencies
 
@@ -67,11 +79,12 @@ None.
       vars_files:
         - vars/main.yml
       roles:
-        - { role: geerlingguy.gitlab }
+        - role: geerlingguy.gitlab
+          gitlab_external_url: "https://gitlab.example.com/"
+          gitlab_rails:
+            gitlab_email_from: "git@example.com"
+            backup_keep_time: "604800"
 
-*Inside `vars/main.yml`*:
-
-    gitlab_external_url: "https://gitlab.example.com/"
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ GitLab LDAP configuration; if `gitlab_ldap_enabled` is `true`, the rest of the c
 Use a custom From email address. Defaults to `gitlab@example.com`
 
     # Custom From email address.
-    gitlab_from_email: "git@example.com"
+    gitlab_email_from: "git@example.com"
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ Whether to create a self-signed certificate for serving GitLab over a secure con
 
 GitLab LDAP configuration; if `gitlab_ldap_enabled` is `true`, the rest of the configuration will tell GitLab how to connect to an LDAP server for centralized authentication.
 
+Use a custom From email address. Defaults to `gitlab@example.com`
+
+    # Custom From email address.
+    gitlab_from_email: "git@example.com"
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,3 +24,6 @@ gitlab_ldap_method: "plain"
 gitlab_ldap_bind_dn: "CN=Username,CN=Users,DC=example,DC=com"
 gitlab_ldap_password: "password"
 gitlab_ldap_base: "DC=example,DC=com"
+
+# Use a  Custom 'From' email address?
+gitlab_from_email: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,4 +26,4 @@ gitlab_ldap_password: "password"
 gitlab_ldap_base: "DC=example,DC=com"
 
 # Use a  Custom 'From' email address?
-gitlab_from_email: false
+gitlab_email_from: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,5 +25,5 @@ gitlab_ldap_bind_dn: "CN=Username,CN=Users,DC=example,DC=com"
 gitlab_ldap_password: "password"
 gitlab_ldap_base: "DC=example,DC=com"
 
-# Use a  Custom 'From' email address?
-gitlab_email_from: false
+# Empty dictionary for other gitlab.rb/gitlab.yml settings
+gitlab_rails:

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -21,8 +21,10 @@ gitlab_rails['ldap_password'] = '{{ gitlab_ldap_password }}'
 gitlab_rails['ldap_allow_username_or_email_login'] = true
 gitlab_rails['ldap_base'] = '{{ gitlab_ldap_base }}'
 
+{% if gitlab_rails %}
 {% for k,v in gitlab_rails | dictsort() %}
 gitlab_rails['{{k}}'] = "{{v}}"
 {% endfor %}
+{% endif %}
 # To change other settings, see:
 # https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/README.md#changing-gitlab-yml-settings

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -21,5 +21,10 @@ gitlab_rails['ldap_password'] = '{{ gitlab_ldap_password }}'
 gitlab_rails['ldap_allow_username_or_email_login'] = true
 gitlab_rails['ldap_base'] = '{{ gitlab_ldap_base }}'
 
+{% if gitlab_email_from %}
+# Custom 'From' email address
+gitlab_rails['gitlab_email_from'] = '{{ gitlab_email_from }}'
+
+{% endif %}
 # To change other settings, see:
 # https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/README.md#changing-gitlab-yml-settings

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -21,10 +21,8 @@ gitlab_rails['ldap_password'] = '{{ gitlab_ldap_password }}'
 gitlab_rails['ldap_allow_username_or_email_login'] = true
 gitlab_rails['ldap_base'] = '{{ gitlab_ldap_base }}'
 
-{% if gitlab_email_from %}
-# Custom 'From' email address
-gitlab_rails['gitlab_email_from'] = '{{ gitlab_email_from }}'
-
-{% endif %}
+{% for k,v in gitlab_rails | dictsort() %}
+gitlab_rails['{{k}}'] = "{{v}}"
+{% endfor %}
 # To change other settings, see:
 # https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/README.md#changing-gitlab-yml-settings


### PR DESCRIPTION
With these changes, the added example `gitlab_rails` dictionary will set add the following settings to `/etc/gitlab/gitlab.rb`:

```
gitlab_rails['gitlab_email_from'] = "git@example.com"
gitlab_rails['backup_keep_time'] = "604800"
```

Other arbitrary keys/values are possible, too.