### PR TITLE
Upgrade GitLab 7.11's installation

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,22 @@
 ---
+- name: enable and start sshd
+  command: >
+    systemctl enable sshd
+    systemctl start sshd
+  when: ansible_os_family == 'RedHat'
+
+- name: enable and start postfix
+  command: >
+    systemctl enable postfix
+    systemctl start postfix
+  when: ansible_os_family == 'RedHat'
+
+- name: config firewall
+  command: >
+    firewall-cmd --permanent --add-service=http
+    systemctl reload firewalld
+  when: ansible_os_family == 'RedHat'
+
 - name: restart gitlab
   command: gitlab-ctl reconfigure
   failed_when: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,20 +26,25 @@
   with_items:
     - openssh-server
     - postfix
+    - curl
   when: ansible_os_family == 'Debian'
 
 - name: Check if GitLab is already installed.
   stat: path=/usr/bin/gitlab-ctl
   register: gitlab_file
 
-- name: Download GitLab .deb package (Debian).
+- name: Download GitLab repository installation script (Debian).
   get_url: >
-    url={{ gitlab_package_url }}
-    dest=/tmp/gitlab.deb
+    url={{ gitlab_repository_installation_script_url }}
+    dest=/tmp/gitlab_install_repository.sh
   when: (gitlab_file.stat.exists == false) and (ansible_os_family == 'Debian')
 
-- name: Install GitLab .deb package (Debian).
-  command: sudo dpkg -i /tmp/gitlab.deb
+- name: Install GitLab repository
+  command: bash /tmp/gitlab_install_repository.sh
+  when: (gitlab_file.stat.exists == false) and (ansible_os_family == 'Debian')
+
+- name: Install GitLab
+  apt: "pkg=gitlab-ce state=installed"
   when: (gitlab_file.stat.exists == false) and (ansible_os_family == 'Debian')
 
 # This will work in Ansible 1.6+.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,12 +12,27 @@
   with_items:
     - openssh-server
     - postfix
+    - curl
   when: ansible_os_family == 'RedHat'
 
 - name: Install GitLab rpm (RedHat).
   command: >
     rpm --nosignature -i {{ gitlab_package_url }}
     creates=/usr/bin/gitlab-ctl
+  when: ansible_os_family == 'RedHat'
+
+- name: Download GitLab repository installation script (RedHat).
+  get_url: >
+    url={{ gitlab_repository_installation_script_url }}
+    dest=/tmp/gitlab_install_repository.sh
+  when: ansible_os_family == 'RedHat'
+
+- name: Install GitLab repository (RedHat)
+  command: bash /tmp/gitlab_install_repository.sh
+  when: ansible_os_family == 'RedHat'
+
+- name: Install GitLab (RedHat)
+  yum: "pkg=gitlab-ce state=installed"
   when: ansible_os_family == 'RedHat'
 
 # Install GitLab and its dependencies (Debian).

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,12 +15,6 @@
     - curl
   when: ansible_os_family == 'RedHat'
 
-- name: Install GitLab rpm (RedHat).
-  command: >
-    rpm --nosignature -i {{ gitlab_package_url }}
-    creates=/usr/bin/gitlab-ctl
-  when: ansible_os_family == 'RedHat'
-
 - name: Download GitLab repository installation script (RedHat).
   get_url: >
     url={{ gitlab_repository_installation_script_url }}

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,3 +1,2 @@
 ---
-gitlab_package_url: "https://downloads-packages.s3.amazonaws.com/ubuntu-12.04/gitlab_7.1.1-omnibus.1-1_amd64.deb"
 gitlab_repository_installation_script_url: "https://packages.gitlab.com/install/repositories/gitlab/gitlab-ce/script.deb.sh"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,2 +1,3 @@
 ---
 gitlab_package_url: "https://downloads-packages.s3.amazonaws.com/ubuntu-12.04/gitlab_7.1.1-omnibus.1-1_amd64.deb"
+gitlab_repository_installation_script_url: "https://packages.gitlab.com/install/repositories/gitlab/gitlab-ce/script.deb.sh"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,3 +1,2 @@
 ---
-gitlab_package_url: "https://downloads-packages.s3.amazonaws.com/centos-6.5/gitlab-7.1.1_omnibus-1.el6.x86_64.rpm"
 gitlab_repository_installation_script_url: "https://packages.gitlab.com/install/repositories/gitlab/gitlab-ce/script.rpm.sh"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,2 +1,3 @@
 ---
 gitlab_package_url: "https://downloads-packages.s3.amazonaws.com/centos-6.5/gitlab-7.1.1_omnibus-1.el6.x86_64.rpm"
+gitlab_repository_installation_script_url: "https://packages.gitlab.com/install/repositories/gitlab/gitlab-ce/script.rpm.sh"


### PR DESCRIPTION
This change introduces GitLab's package source into apt's list of sources.

Tested with these boxes:
- geerlingguy/centos6
- geerlingguy/centos6
- geerlingguy/ubuntu1404

Travis' passing. Here's the role in Ansible Galaxy: https://galaxy.ansible.com/list#/roles/3895

I hope this is helpful.