### PR TITLE
Fix problems with permissions on ubuntu trusty.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,6 +36,7 @@
 # Install GitLab and its dependencies (Debian).
 - name: Install GitLab dependencies (Debian).
   apt: "name={{ item }} state=installed"
+  sudo: yes
   with_items:
     - openssh-server
     - postfix
@@ -50,10 +51,12 @@
 
 - name: Install GitLab repository
   command: bash /tmp/gitlab_install_repository.sh
+  sudo: yes
   when: (gitlab_file.stat.exists == false) and (ansible_os_family == 'Debian')
 
 - name: Install GitLab
   apt: "name=gitlab-ce state=installed"
+  sudo: yes
   when: (gitlab_file.stat.exists == false) and (ansible_os_family == 'Debian')
 
 # Start and configure GitLab. Sometimes the first run fails, but after that,
@@ -62,6 +65,7 @@
   command: >
     gitlab-ctl reconfigure
     creates=/var/opt/gitlab/bootstrapped
+  sudo: yes
   failed_when: false
 
 - name: Create GitLab SSL configuration folder.
@@ -71,12 +75,14 @@
     owner: root
     group: root
     mode: 0700
+  sudo: yes
   when: gitlab_create_self_signed_cert
 
 - name: Create self-signed certificate.
   command: >
     openssl req -new -nodes -x509 -subj "{{ gitlab_self_signed_cert_subj }}" -days 3650 -keyout {{ gitlab_ssl_certificate_key }} -out {{ gitlab_ssl_certificate }} -extensions v3_ca
     creates={{ gitlab_ssl_certificate }}
+  sudo: yes
   when: gitlab_create_self_signed_cert
 
 - name: Copy GitLab configuration file.
@@ -86,4 +92,5 @@
     owner: root
     group: root
     mode: 0600
+  sudo: yes
   notify: restart gitlab


### PR DESCRIPTION
I have some problems with using this role.

I use vagrant with vagrantfile:
```
Vagrant.configure(2) do |config|
    config.vm.box = "ubuntu/trusty64"
    config.vm.define "gitlab" do |gitlab|
        gitlab.vm.hostname = "gocd-agent"
        gitlab.vm.network "private_network", ip: "192.168.50.3"
    end
    config.vm.provision "ansible" do |ansible|
        ansible.groups = {
            "gitlab" => ["gitlab"],
            "all_groups:children" => ["gitlab"]
        }
        ansible.limit = "all"
        ansible.playbook = "../ansible/gitlab.yml"
    end
end
```

and in `gitlab.yml`:
```
- hosts: gitlab
  roles:
     - {
        role: geerlingguy.gitlab,
        gitlab_external_url: "https://192.168.50.3/"
      }
```

And when I try run `vagrant up` I get some errors with permissions and I fix this and role works correctly.