### PR TITLE
added variables incl mail and Gitlab CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,27 @@ Whether to create a self-signed certificate for serving GitLab over a secure con
 
 GitLab LDAP configuration; if `gitlab_ldap_enabled` is `true`, the rest of the configuration will tell GitLab how to connect to an LDAP server for centralized authentication.
 
+    gitlab_time_zone: "CET"
+
+Gitlab timezone
+
+    gitlab_email_from: 'gitlab@gitlab.com'
+    gitlab_email_display_name: 'Gitlab'
+    gitlab_email_reply_to: 'gitlab@gitlab.com'
+
+Gitlab system mail configuration.
+
+    gitlab_ci_external_url: "http://ci.gitlab.com"
+    gitlab_ci_app_id: '12345'
+    gitlab_ci_app_secret: '67890'
+
+Though you'll need to have Gitlab up and running to obtain an `app_id` and `app_secret`, this will come in handy with rolling updates via Ansible after initial install.
+
+    gitlab_ci_email_from: 'CI'
+    gitlab_ci_support_email: 'ci@gitlab.com'
+
+Gitlab CI system mail configuration.
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,5 +22,20 @@ gitlab_ldap_bind_dn: "CN=Username,CN=Users,DC=example,DC=com"
 gitlab_ldap_password: "password"
 gitlab_ldap_base: "DC=example,DC=com"
 
+# Timezone
+gitlab_time_zone: "CET"
+
+# Gitlab mail
+gitlab_email_from: 'gitlab@gitlab.com'
+gitlab_email_display_name: 'Gitlab'
+gitlab_email_reply_to: 'gitlab@gitlab.com'
+
 # Probably best to leave this as the default, unless doing testing.
 gitlab_restart_handler_failed_when: 'gitlab_restart.rc != 0'
+
+# CI config
+gitlab_ci_external_url: "http://ci.gitlab.com"
+gitlab_ci_app_id: '12345'
+gitlab_ci_app_secret: '67890'
+gitlab_ci_email_from: 'CI'
+gitlab_ci_support_email: 'ci@gitlab.com'

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -6,6 +6,9 @@ nginx['redirect_http_to_https'] = {{ gitlab_redirect_http_to_https }}
 nginx['ssl_certificate'] = "{{ gitlab_ssl_certificate }}"
 nginx['ssl_certificate_key'] = "{{ gitlab_ssl_certificate_key }}"
 
+# Timezone
+gitlab_rails['time_zone'] = "{{ gitlab_time_zone }}"
+
 # The directory where Git repositories will be stored.
 git_data_dir "{{ gitlab_git_data_dir }}"
 
@@ -21,5 +24,17 @@ gitlab_rails['ldap_password'] = '{{ gitlab_ldap_password }}'
 gitlab_rails['ldap_allow_username_or_email_login'] = true
 gitlab_rails['ldap_base'] = '{{ gitlab_ldap_base }}'
 
+# Mails
+
+gitlab_rails['gitlab_email_from'] = '{{ gitlab_email_from }}'
+gitlab_rails['gitlab_email_display_name'] = '{{ gitlab_email_display_name }}'
+gitlab_rails['gitlab_email_reply_to'] = '{{ gitlab_email_reply_to }}'
+
 # To change other settings, see:
 # https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/README.md#changing-gitlab-yml-settings
+
+# CI config
+ci_external_url "{{ gitlab_ci_external_url }}"
+gitlab_ci['gitlab_server'] = { "url" => '{{ gitlab_external_url }}', "app_id" => '{{ gitlab_ci_app_id }}', "app_secret" => '{{ gitlab_ci_app_secret }}' }
+gitlab_ci['gitlab_ci_email_from'] = '{{ gitlab_ci_email_from }}'
+gitlab_ci['gitlab_ci_support_email'] = '{{ gitlab_ci_support_email }}'


### PR DESCRIPTION
I've been using this role to setup my Gitlab instance and have been quite pleased with it, and I'd like to keep using this role while maintaining this Gitlab instance. Some missing variables make this a somewhat hack-y task especially since I'm also using the Gitlab CI with the Omnibus install. Hence, pull request.

These changes allow some additional variables to be set, including:
- timezone
- system mails sender/reply-to for Gitlab and Gitlab CI
- Gitlab CI URL and application.yml configuration

The later one prevents Gitlab CI from breaking, when one has it setup manually, and runs the playbook with this role again since only the variables from the template are being picked up during `gitlab-ctl reconfigure`. In one of my tests, I had Gitlab CI run the playbook on it's own server with this role, which ~~broke~~ disabled Gitlab CI halfway the build ^^

I've been pondering if it would be worth the effort to make the entire `gitlab.rb` file's variables available through a template, but that may be an exercise in futility for the most part.

**edit**: just read #16 so this may go into that approach, if so I apologise. Though this role can still disable a manually configured Gitlab CI instance which may be something to ponder about if you decide to to pull in these changes.
