### PR TITLE
Added SMTP variables. Updated documentation accordingly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,22 @@ How long to keep local backups (useful if you don't want backups to fill up your
 
 Gitlab system mail configuration. Disabled by default; set `gitlab_email_enabled` to `true` to enable, and make sure you enter valid from/reply-to values.
 
+    # SMTP Configuration
+    gitlab_smtp_enable: "false"
+    gitlab_smtp_address: "smtp.server"
+    gitlab_smtp_port: "465"
+    gitlab_smtp_user_name: "smtp user"
+    gitlab_smtp_password: "smtp password"
+    gitlab_smtp_domain: "example.com"
+    gitlab_smtp_authentication: "login"
+    gitlab_smtp_enable_starttls_auto: "true"
+    gitlab_smtp_tls: "false"
+    gitlab_smtp_openssl_verify_mode: "none"
+    gitlab_smtp_ca_path: "/etc/ssl/certs"
+    gitlab_smtp_ca_file: "/etc/ssl/certs/ca-certificates.crt"
+
+Gitlab SMTP configuration; of `gitlab_smtp_enable` is `true`, the rest of the configuration will tell GitLab how to send mails using an smtp server.
+
     gitlab_nginx_listen_port: 8080
 
 If you are running GitLab behind a reverse proxy, you may want to override the listen port to something else.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,20 @@ gitlab_ldap_bind_dn: "CN=Username,CN=Users,DC=example,DC=com"
 gitlab_ldap_password: "password"
 gitlab_ldap_base: "DC=example,DC=com"
 
+# SMTP Configuration
+gitlab_smtp_enable: "false"
+gitlab_smtp_address: "smtp.server"
+gitlab_smtp_port: "465"
+gitlab_smtp_user_name: "smtp user"
+gitlab_smtp_password: "smtp password"
+gitlab_smtp_domain: "example.com"
+gitlab_smtp_authentication: "login"
+gitlab_smtp_enable_starttls_auto: "true"
+gitlab_smtp_tls: "false"
+gitlab_smtp_openssl_verify_mode: "none"
+gitlab_smtp_ca_path: "/etc/ssl/certs"
+gitlab_smtp_ca_file: "/etc/ssl/certs/ca-certificates.crt"
+
 # Probably best to leave this as the default, unless doing testing.
 gitlab_restart_handler_failed_when: 'gitlab_restart.rc != 0'
 

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -40,5 +40,21 @@ nginx['listen_port'] = "{{ gitlab_nginx_listen_port }}"
 nginx['listen_https'] = "{{ gitlab_nginx_listen_https }}"
 {% endif %}
 
+# Use smtp instead of sendmail/postfix
+# More details and example configuration at
+# https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/doc/settings/smtp.md
+gitlab_rails['smtp_enable'] = {{ gitlab_smtp_enable }}
+gitlab_rails['smtp_address'] = '{{ gitlab_smtp_address }}'
+gitlab_rails['smtp_port'] = {{ gitlab_smtp_port }}
+gitlab_rails['smtp_user_name'] = '{{ gitlab_smtp_user_name }}'
+gitlab_rails['smtp_password'] = '{{ gitlab_smtp_password }}'
+gitlab_rails['smtp_domain'] = '{{ gitlab_smtp_domain }}'
+gitlab_rails['smtp_authentication'] = '{{ gitlab_smtp_authentication }}'
+gitlab_rails['smtp_enable_starttls_auto'] = {{ gitlab_smtp_enable_starttls_auto }}
+gitlab_rails['smtp_tls'] = {{ gitlab_smtp_tls }}
+gitlab_rails['smtp_openssl_verify_mode'] = '{{ gitlab_smtp_openssl_verify_mode }}'
+gitlab_rails['smtp_ca_path'] = '{{ gitlab_smtp_ca_path }}'
+gitlab_rails['smtp_ca_file'] = '{{ gitlab_smtp_ca_file }}'
+
 # To change other settings, see:
 # https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/README.md#changing-gitlab-yml-settings


### PR DESCRIPTION
I am using your role in order to deploy gitlab servers, but I always have to change the configuration to enable sending mail via our smtp server. That's why I decided to add this functionality.

Kindly review this pull request, and let me know your thoughts. Do you think that this smtp-related configuration is too much to be included in your generic gitlab role? If you want to merge this but you have any comments on my commit, please let me know so I can fix it.
