### PR TITLE
Add Nginx listen_addresses suport

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ GitLab SSL configuration; tells GitLab to redirect normal http requests to https
     gitlab_create_self_signed_cert: true
     gitlab_self_signed_cert_subj: "/C=US/ST=Missouri/L=Saint Louis/O=IT/CN=gitlab"
 
+GitLab listen address; tells GitLab to listen for incoming connections on the specified IP addresses.  Supports wildcards.
+
+    # Listen on all IPv4 addresses (default)
+    gitlab_nginx_listen_addresses: "['*']"
+    # Listen on all IPv4 and IPv6 addresses:
+    gitlab_nginx_listen_addresses: "['*', '[::]']"
+
 Whether to create a self-signed certificate for serving GitLab over a secure connection. Set `gitlab_self_signed_cert_subj` according to your locality and organization.
 
     # LDAP Configuration.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,9 @@ gitlab_redirect_http_to_https: "true"
 gitlab_ssl_certificate: "/etc/gitlab/ssl/gitlab.crt"
 gitlab_ssl_certificate_key: "/etc/gitlab/ssl/gitlab.key"
 
+# Nginx listen addresses
+gitlab_nginx_listen_addresses: "['*']"
+
 # SSL Self-signed Certificate Configuration.
 gitlab_create_self_signed_cert: true
 gitlab_self_signed_cert_subj: "/C=US/ST=Missouri/L=Saint Louis/O=IT/CN=gitlab"

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -6,6 +6,9 @@ nginx['redirect_http_to_https'] = {{ gitlab_redirect_http_to_https }}
 nginx['ssl_certificate'] = "{{ gitlab_ssl_certificate }}"
 nginx['ssl_certificate_key'] = "{{ gitlab_ssl_certificate_key }}"
 
+# Listen addresses
+nginx['listen_addresses'] = {{ gitlab_nginx_listen_addresses }}
+
 # The directory where Git repositories will be stored.
 git_data_dir "{{ gitlab_git_data_dir }}"
 


### PR DESCRIPTION
Adds support for listen_addresses, in my case so that I can have GitLab listen on IPv4 and IPv6 simultaneously.