### PR TITLE
Fixes #29 : New http target for the running test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
 
   # Make sure GitLab is running.
   - >
-    curl --insecure -s -o /dev/null -w "%{http_code}" https://localhost/users/sign_in
+    curl --insecure -s -o /dev/null -w "%{http_code}" https://localhost/users/password/new
     | grep -q '200'
     && (echo 'Status code 200 test: pass' && exit 0)
     || (echo 'Status code 200 test: fail' && exit 1)


### PR DESCRIPTION
Test running Gitlab targets localhost/users/sign_in which is a redirection (http 302) to a localhost/users/password/edit?reset_password_token=xxx . And unfortunately, the token is a random string. 

So I propose to target localhost/users/password/new which is a http 200 return code. And in my opinion it is also good to determine if Gitlab is up and running.