### PR TITLE
Add Email Setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ Whether to create a self-signed certificate for serving GitLab over a secure con
 
 GitLab LDAP configuration; if `gitlab_ldap_enabled` is `true`, the rest of the configuration will tell GitLab how to connect to an LDAP server for centralized authentication.
 
+    gitlab_email_enabled: true
+    gitlab_email_from: 'gitlab@gitlab.com'
+    gitlab_email_display_name: 'Gitlab'
+    gitlab_email_reply_to: 'gitlab@gitlab.com'
+
+Gitlab system mail configuration. By default, email option is disabled, and the rest of the configuration is not set.
+
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,3 +24,6 @@ gitlab_ldap_base: "DC=example,DC=com"
 
 # Probably best to leave this as the default, unless doing testing.
 gitlab_restart_handler_failed_when: 'gitlab_restart.rc != 0'
+
+# Optionnal settings
+gitlab_email_enabled: "false"

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -3,7 +3,7 @@ external_url "{{ gitlab_external_url }}"
 
 # gitlab.yml configuration
 gitlab_rails['gitlab_email_enabled'] = {{ gitlab_email_enabled }}
-{% if gitlab_email_enabled %}
+{% if gitlab_email_enabled == "true" %}
 gitlab_rails['gitlab_email_from'] = "{{ gitlab_email_from }}"
 gitlab_rails['gitlab_email_display_name'] = "{{ gitlab_email_display_name }}"
 gitlab_rails['gitlab_email_reply_to'] = "{{ gitlab_email_reply_to }}"

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -1,6 +1,14 @@
 # The URL through which GitLab will be accessed.
 external_url "{{ gitlab_external_url }}"
 
+# gitlab.yml configuration
+gitlab_rails['gitlab_email_enabled'] = {{ gitlab_email_enabled }}
+{% if gitlab_email_enabled %}
+gitlab_rails['gitlab_email_from'] = "{{ gitlab_email_from }}"
+gitlab_rails['gitlab_email_display_name'] = "{{ gitlab_email_display_name }}"
+gitlab_rails['gitlab_email_reply_to'] = "{{ gitlab_email_reply_to }}"
+{% endif %}
+
 # Whether to redirect http to https.
 nginx['redirect_http_to_https'] = {{ gitlab_redirect_http_to_https }}
 nginx['ssl_certificate'] = "{{ gitlab_ssl_certificate }}"


### PR DESCRIPTION
I propose to add the email setting.
This add into the *gitlab.yml* the parameters below:
```
    email_from: example@example.com
    email_display_name: GitLab
    email_reply_to: noreply@example.com
```

See official documentation :
https://gitlab.com/gitlab-org/gitlab-ce/blob/master/config/gitlab.yml.example#L66-72


~~Note: I added the PR #30 in order to avoid the issue #29 .~~

