### PR TITLE
Add Nginx Listen Port and HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ Whether to create a self-signed certificate for serving GitLab over a secure con
 
 GitLab LDAP configuration; if `gitlab_ldap_enabled` is `true`, the rest of the configuration will tell GitLab how to connect to an LDAP server for centralized authentication.
 
+    gitlab_nginx_listen_port: 8080
+
+If you are running GitLab behind a reverse proxy, you may want to override the listen port to something else.
+
+    gitlab_nginx_listen_https: false
+
+If you are running GitLab behind a reverse proxy, you may wish to terminate SSL at another proxy server or load balancer
+
 ## Dependencies
 
 None.

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -21,5 +21,14 @@ gitlab_rails['ldap_password'] = '{{ gitlab_ldap_password }}'
 gitlab_rails['ldap_allow_username_or_email_login'] = true
 gitlab_rails['ldap_base'] = '{{ gitlab_ldap_base }}'
 
+# GitLab Nginx
+## See https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/doc/settings/nginx.md
+{% if gitlab_nginx_listen_port is defined %}
+nginx['listen_port'] = "{{ gitlab_nginx_listen_port }}"
+{% endif %}
+{% if gitlab_nginx_listen_https is defined %}
+nginx['listen_https'] = "{{ gitlab_nginx_listen_https }}"
+{% endif %}
+
 # To change other settings, see:
 # https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/README.md#changing-gitlab-yml-settings


### PR DESCRIPTION
In order to supporting proxied SSL, I propose to add these two parameters into the *gitlab.yml*: 
```
nginx['listen_port'] = 80
nginx['listen_https'] = false
```

See official documentation :
https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/doc/settings/nginx.md#supporting-proxied-ssl

~~Note: I added the PR #30 in order to avoid the issue #29 .~~