### PR TITLE
Add validate_certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Gitlab timezone.
 
 How long to keep local backups (useful if you don't want backups to fill up your drive!).
 
+    gitlab_download_validate_certs: yes
+
+Controls whether to validate certificates when downloading the GitLab installation repository install script.
+
     # Email configuration.
     gitlab_email_enabled: "false"
     gitlab_email_from: "gitlab@example.com"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,6 +48,7 @@ gitlab_restart_handler_failed_when: 'gitlab_restart.rc != 0'
 # Optional settings.
 gitlab_time_zone: "UTC"
 gitlab_backup_keep_time: "604800"
+gitlab_download_validate_certs: yes
 
 # Email configuration.
 gitlab_email_enabled: "false"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,7 @@
   get_url:
     url: "{{ gitlab_repository_installation_script_url }}"
     dest: /tmp/gitlab_install_repository.sh
+    validate_certs: "{{ gitlab_download_validate_certs }}"
   when: (gitlab_file.stat.exists == false)
 
 - name: Install GitLab repository


### PR DESCRIPTION
As you suggest for the ansible-role-sonar, by default it is set to yes.

Source: https://docs.ansible.com/ansible/get_url_module.html
