### PR TITLE
Local ssl certificates #11

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,7 @@ gitlab_ssl_certificate: "/etc/gitlab/ssl/gitlab.crt"
 gitlab_ssl_certificate_key: "/etc/gitlab/ssl/gitlab.key"
 
 # SSL Self-signed Certificate Configuration.
-gitlab_create_self_signed_cert: true
+gitlab_use_self_signed_cert: true
 gitlab_self_signed_cert_subj: "/C=US/ST=Missouri/L=Saint Louis/O=IT/CN=gitlab"
 
 # SSL Deploy Certificate Configuration.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,30 @@ gitlab_ssl_certificate_key: "/etc/gitlab/ssl/gitlab.key"
 gitlab_create_self_signed_cert: true
 gitlab_self_signed_cert_subj: "/C=US/ST=Missouri/L=Saint Louis/O=IT/CN=gitlab"
 
+# SSL Deploy Certificate Configuration.
+#   - This option and `gitlab_create_self_signed_cert` exclude each other
+#     if `ssl_certificate` and `ssl_certificate_key` are defined and `!= ''`
+#     the script automatically will deploy those certificates
+#   - Please do NOT put you certificates in this file. And do NOT push any
+#     certificate to github or any type of storage service.
+#     usage:
+#       - Override this variables inside a file and and use `vars_files:`
+#         Ansible module. Other approach is to use a file inside
+#         `group_vars/all_secrets`
+#       - ENCRIPT the file with Ansible vault:
+#         Your SSL certificates should never be uploaded in plain text. SSH
+#         connection work in plain text by default. To solve this problem
+#         Ansible provides vault. Ansible vault will encript a file with
+#         variables. The encripted variables will be decripted in the
+#         destination machine.
+#
+#             $ touch group_vars/secrets_all.yml
+#             # copy you certificates inside group_vars/secrets_all.yml
+#             $ ansible-vault encrypt group_vars/secrets_all.yml
+#
+ssl_certificate: ''
+ssl_certificate_key: ''
+
 # LDAP Configuration.
 gitlab_ldap_enabled: "false"
 gitlab_ldap_host: "example.com"

--- a/defaults/secrets.example
+++ b/defaults/secrets.example
@@ -1,0 +1,46 @@
+---
+
+### --- GITLAB-CI --- ###
+#
+# SSL Deploy Certificate Configuration.
+#   - This option and `gitlab_create_self_signed_cert` exclude each other
+#     if `ssl_certificate` and `ssl_certificate_key` are defined and `!= ''`
+#     the script automatically will deploy those certificates
+#   - Please do NOT put you certificates in this file. And do NOT push any
+#     certificate to github or any type of storage service.
+#     usage:
+#       - Override this variables inside a file and and use `vars_files:`
+#         Ansible module. Other approach is to use a file inside
+#         `group_vars/all_secrets`
+#       - ENCRIPT the file with Ansible vault:
+#         Your SSL certificates should never be uploaded in plain text. SSH
+#         connection work in plain text by default. To solve this problem
+#         Ansible provides vault. Ansible vault will encript a file with
+#         variables. The encripted variables will be decripted in the
+#         destination machine.
+#
+# commands:
+#
+# $ cd /dir/with/your/certificates
+#
+# $ openssl req -new -nodes -x509                         \
+#           -subj "/C=US/ST=TX/L=Houston/O=IT/CN=gitlab"  \
+#           -days 3650 -keyout gitlab_ssl_certificate_key \
+#           -out gitlab_ssl_certificate                   \
+#           -extensions v3_ca
+#
+# $ cd /group_vars
+#
+# $ touch secrets
+#
+# $ ansible-vault encrypt secrets
+
+ssl_certificate: |
+  -----BEGIN CERTIFICATE-----
+  copy your certificate here, Notice the two spaces at the begining of the line
+  -----END CERTIFICATE-----
+
+ssl_certificate_key: |
+  -----BEGIN RSA PRIVATE KEY-----
+  copy your key here, Notice the two spaces at the begining of the line
+  -----END RSA PRIVATE KEY-----

--- a/tasks/check_vars.yml
+++ b/tasks/check_vars.yml
@@ -1,0 +1,18 @@
+---
+
+- name: init vars to select 'create' or 'deploy' ssl certificates
+  set_fact:
+    gitlab_deploy_self_signed_cert: false
+    gitlab_create_self_signed_cert: false
+
+- name: select 'deploy' ssl certificates
+  set_fact:
+    gitlab_deploy_self_signed_cert: true
+  register: deploy_out
+  when: "'{{ ssl_certificate }}'     != '' and
+         '{{ ssl_certificate_key }}' != '' "
+
+- name: select 'create' ssl certificates
+  set_fact:
+    gitlab_create_self_signed_cert: true
+  when: "not {{ gitlab_deploy_self_signed_cert }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,6 +59,18 @@
     creates={{ gitlab_ssl_certificate }}
   when: gitlab_create_self_signed_cert
 
+- name: Deploy self-signed certificate.
+  template:
+    src={{ item.src }}
+    dest={{ item.dest }}
+    mode=0644
+  with_items:
+    - src:  "ssl_certificate.j2"
+      dest: "{{ gitlab_ssl_certificate }}"
+    - src:  "ssl_certificate_key.j2"
+      dest: "{{ gitlab_ssl_certificate_key }}"
+  when: "{{ gitlab_deploy_self_signed_cert }}"
+
 - name: Copy GitLab configuration file.
   template:
     src: gitlab.rb.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+
+- include: check_vars.yml
+  when: "{{ gitlab_use_self_signed_cert }}"
+
 - name: Include OS-specific variables.
   include_vars: "{{ ansible_os_family }}.yml"
 
@@ -47,7 +51,7 @@
     owner: root
     group: root
     mode: 0700
-  when: gitlab_create_self_signed_cert
+  when: gitlab_use_self_signed_cert
 
 - name: Create self-signed certificate.
   command: >

--- a/templates/ssl_certificate.j2
+++ b/templates/ssl_certificate.j2
@@ -1,0 +1,1 @@
+{{ ssl_certificate }}

--- a/templates/ssl_certificate_key.j2
+++ b/templates/ssl_certificate_key.j2
@@ -1,0 +1,1 @@
+{{ ssl_certificate_key }}


### PR DESCRIPTION
Deploy self signed certificates. I have several questions:
- I have tested the role locally with a CentOS Vm. But I don't know how to include this in Travis.
- There is a documentation file in `defaults/secrets.example` I belief that it will be better to integrate that documentation either in `defaults/main.yml` or in the `README.md`. I am open to suggestions.
