### PR TITLE
Add gitlab fully qualified domain name.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,14 +1,16 @@
 ---
 # General config.
-gitlab_external_url: "https://gitlab/"
+# fully qualified domain name: your.gitlab.domain.example.com
+gitlab_fqdn: gitlab
+gitlab_external_url: "https://{{ gitlab_fqdn }}/"
 gitlab_git_data_dir: "/var/opt/gitlab/git-data"
 gitlab_edition: "gitlab-ce"
 gitlab_backup_path: "/var/opt/gitlab/backups"
 
 # SSL Configuration.
 gitlab_redirect_http_to_https: "true"
-gitlab_ssl_certificate: "/etc/gitlab/ssl/gitlab.crt"
-gitlab_ssl_certificate_key: "/etc/gitlab/ssl/gitlab.key"
+gitlab_ssl_certificate: "/etc/gitlab/ssl/{{ gitlab_fqdn }}.crt"
+gitlab_ssl_certificate_key: "/etc/gitlab/ssl/{{ gitlab_fqdn }}.key"
 
 # SSL Self-signed Certificate Configuration.
 gitlab_create_self_signed_cert: "true"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,16 +1,16 @@
 ---
 # General config.
 # fully qualified domain name: your.gitlab.domain.example.com
-gitlab_fqdn: gitlab
-gitlab_external_url: "https://{{ gitlab_fqdn }}/"
+gitlab_domain: gitlab
+gitlab_external_url: "https://{{ gitlab_domain }}/"
 gitlab_git_data_dir: "/var/opt/gitlab/git-data"
 gitlab_edition: "gitlab-ce"
 gitlab_backup_path: "/var/opt/gitlab/backups"
 
 # SSL Configuration.
 gitlab_redirect_http_to_https: "true"
-gitlab_ssl_certificate: "/etc/gitlab/ssl/{{ gitlab_fqdn }}.crt"
-gitlab_ssl_certificate_key: "/etc/gitlab/ssl/{{ gitlab_fqdn }}.key"
+gitlab_ssl_certificate: "/etc/gitlab/ssl/{{ gitlab_domain }}.crt"
+gitlab_ssl_certificate_key: "/etc/gitlab/ssl/{{ gitlab_domain }}.key"
 
 # SSL Self-signed Certificate Configuration.
 gitlab_create_self_signed_cert: "true"


### PR DESCRIPTION
Introduce  `gitlab_fqdn`, stands for _gitlab fully qualified domain name_.

```
gitlab_fqdn: your.gitlab.complete.domain.name.com
```

By defining the variable `gitlab_fqdn` it is easier to redefine the variables:

```
gitlab_fqdn: gitlab
gitlab_external_url: "https://{{ gitlab_fqdn }}/"
gitlab_ssl_certificate: "/etc/gitlab/ssl/{{ gitlab_fqdn }}.crt"
gitlab_ssl_certificate_key: "/etc/gitlab/ssl/{{ gitlab_fqdn }}.key"
```

Not only that. When using the Ansible role [`ansible-role-gitlab`](https://github.com/geerlingguy/ansible-role-gitlab) with [`ansible-role-gitlab-runner`](https://github.com/AdrianGPrado/ansible-role-gitlab-runner) (under development), this method allows to define:

```
gitlab_runner_coordinator_url: 'https://{{ gitlab_fqdn }}/ci'
# gitlab_runner_conf_path defines the configuration path in `gitlab-runner` role
# /etc/gitlab-runner/ if gitlab runner is executed as root in *nix systems.
# ~/.gitlab-runner/    if gitlab-runner is executed as non-root in *nix systems.
# ./                            if gitlab-runner is executed in other systems.
gitlab_runner_tls_ca_file: '{{ gitlab_runner_conf_path }}/certs/{{ gitlab_fqdn }}.crt'
```

This way by over-writing one variable, it is possible to redefine
five variables in two roles, simplifying the `groups_vars/all` file
and the risk of making mistakes.
