### PR TITLE
fix translation from boolen variables to gitlab configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The URL at which the GitLab instance will be accessible. This is set as the `ext
 The `gitlab_git_data_url` is the location where all the Git repositories will be stored. You can use a shared drive or any path on the system.
 
     # SSL Configuration.
-    gitlab_redirect_http_to_https: "true"
+    gitlab_redirect_http_to_https: true
     gitlab_ssl_certificate: "/etc/gitlab/ssl/gitlab.crt"
     gitlab_ssl_certificate_key: "/etc/gitlab/ssl/gitlab.key"
 
@@ -39,7 +39,7 @@ GitLab SSL configuration; tells GitLab to redirect normal http requests to https
 Whether to create a self-signed certificate for serving GitLab over a secure connection. Set `gitlab_self_signed_cert_subj` according to your locality and organization.
 
     # LDAP Configuration.
-    gitlab_ldap_enabled: "false"
+    gitlab_ldap_enabled: false
     gitlab_ldap_host: "example.com"
     gitlab_ldap_port: "389"
     gitlab_ldap_uid: "sAMAccountName"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,7 @@ gitlab_create_self_signed_cert: true
 gitlab_self_signed_cert_subj: "/C=US/ST=Missouri/L=Saint Louis/O=IT/CN=gitlab"
 
 # LDAP Configuration.
-gitlab_ldap_enabled: "false"
+gitlab_ldap_enabled: false
 gitlab_ldap_host: "example.com"
 gitlab_ldap_port: "389"
 gitlab_ldap_uid: "sAMAccountName"
@@ -30,7 +30,7 @@ gitlab_time_zone: "UTC"
 gitlab_backup_keep_time: "604800"
 
 # Email configuration.
-gitlab_email_enabled: "false"
+gitlab_email_enabled: false
 gitlab_email_from: 'gitlab@example.com'
 gitlab_email_display_name: 'Gitlab'
 gitlab_email_reply_to: 'gitlab@example.com'

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -4,15 +4,17 @@ external_url "{{ gitlab_external_url }}"
 # gitlab.yml configuration
 gitlab_rails['time_zone'] = "{{ gitlab_time_zone }}"
 gitlab_rails['backup_keep_time'] = {{ gitlab_backup_keep_time }}
-gitlab_rails['gitlab_email_enabled'] = {{ gitlab_email_enabled }}
-{% if gitlab_email_enabled == "true" %}
+{% if gitlab_email_enabled == true %}
+gitlab_rails['gitlab_email_enabled'] = true
 gitlab_rails['gitlab_email_from'] = "{{ gitlab_email_from }}"
 gitlab_rails['gitlab_email_display_name'] = "{{ gitlab_email_display_name }}"
 gitlab_rails['gitlab_email_reply_to'] = "{{ gitlab_email_reply_to }}"
+{% else %}
+gitlab_rails['gitlab_email_enabled'] = false
 {% endif %}
 
 # Whether to redirect http to https.
-nginx['redirect_http_to_https'] = {{ gitlab_redirect_http_to_https }}
+nginx['redirect_http_to_https'] = {{ 'true' if (gitlab_redirect_http_to_https == true) else 'false' }}
 nginx['ssl_certificate'] = "{{ gitlab_ssl_certificate }}"
 nginx['ssl_certificate_key'] = "{{ gitlab_ssl_certificate_key }}"
 
@@ -21,7 +23,8 @@ git_data_dir "{{ gitlab_git_data_dir }}"
 
 # These settings are documented in more detail at
 # https://gitlab.com/gitlab-org/gitlab-ce/blob/master/config/gitlab.yml.example#L118
-gitlab_rails['ldap_enabled'] = {{ gitlab_ldap_enabled }}
+{% if gitlab_ldap_enabled == true %}
+gitlab_rails['ldap_enabled'] = true
 gitlab_rails['ldap_host'] = '{{ gitlab_ldap_host }}'
 gitlab_rails['ldap_port'] = {{ gitlab_ldap_port }}
 gitlab_rails['ldap_uid'] = '{{ gitlab_ldap_uid }}'
@@ -30,6 +33,9 @@ gitlab_rails['ldap_bind_dn'] = '{{ gitlab_ldap_bind_dn }}'
 gitlab_rails['ldap_password'] = '{{ gitlab_ldap_password }}'
 gitlab_rails['ldap_allow_username_or_email_login'] = true
 gitlab_rails['ldap_base'] = '{{ gitlab_ldap_base }}'
+{% else %}
+gitlab_rails['ldap_enabled'] = false
+{% endif %}
 
 # GitLab Nginx
 ## See https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/doc/settings/nginx.md


### PR DESCRIPTION
GitLab and Ansible expect different representations of boolean values. This changes make sure we can use all forms of boolean values in Ansible that get mapped to valid GitLab configuration.