### PR TITLE
extend nginx configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ If you are running GitLab behind a reverse proxy, you may wish to terminate SSL 
 
 If you want to enable [2-way SSL Client Authentication](https://docs.gitlab.com/omnibus/settings/nginx.html#enable-2-way-ssl-client-authentication), set `gitlab_nginx_ssl_verify_client` and add a path to the client certificate in `gitlab_nginx_ssl_client_certificate`.
 
+    gitlab_custom_server_config: 'listen [::]:80;'
+
+The line in `gitlab_custom_server_config` is added to the builtin nginx server configurtion. In this case nginx also listens to any IPv6 address.
+
+    gitlab_real_ip_trusted_addresses: ['2001:db8::/32']
+
+Optional list of trusted proxy servers (for example when using a external proxy for SSL termination). The `X-Real-IP` header of HTTP requests from hosts in this list is trusted to be the real client IP address.
+
 ## Dependencies
 
 None.

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ The edition of GitLab to install. Usually either `gitlab-ce` (Community Edition)
 
     # SSL Configuration.
     gitlab_redirect_http_to_https: "true"
-    gitlab_ssl_certificate: "/etc/gitlab/ssl/gitlab.crt"
-    gitlab_ssl_certificate_key: "/etc/gitlab/ssl/gitlab.key"
+    gitlab_https_cert: "/etc/gitlab/ssl/gitlab.crt"
+    gitlab_https_key: "/etc/gitlab/ssl/gitlab.key"
 
 GitLab SSL configuration; tells GitLab to redirect normal http requests to https, and the path to the certificate and key (the default values will work for automatic self-signed certificate creation, if set to `true` in the variable below).
 
@@ -111,9 +111,17 @@ If you want to enable [2-way SSL Client Authentication](https://docs.gitlab.com/
 
 The line in `gitlab_custom_server_config` is added to the builtin nginx server configurtion. In this case nginx also listens to any IPv6 address.
 
-    gitlab_real_ip_trusted_addresses: ['2001:db8::/32']
+    gitlab_nginx_real_ip_trusted_addresses: ['2001:db8::/32']
 
 Optional list of trusted proxy servers (for example when using a external proxy for SSL termination). The `X-Real-IP` header of HTTP requests from hosts in this list is trusted to be the real client IP address.
+
+    gitlab_nginx_listen_https : no
+
+Enables SSL/TLS encryption on nginx. (Default: no)
+
+    gitlab_nginx_listen_port: {{ 443 if gitlab_nginx_listen_https else 80 }}
+
+The listening port of the webserver. Default port is `443`, when encryption is enabled, or `80`.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,8 +7,8 @@ gitlab_backup_path: "/var/opt/gitlab/backups"
 
 # SSL Configuration.
 gitlab_redirect_http_to_https: "true"
-gitlab_ssl_certificate: "/etc/gitlab/ssl/gitlab.crt"
-gitlab_ssl_certificate_key: "/etc/gitlab/ssl/gitlab.key"
+gitlab_https_certificate: "/etc/gitlab/ssl/gitlab.crt"
+gitlab_https_certificate_key: "/etc/gitlab/ssl/gitlab.key"
 
 # SSL Self-signed Certificate Configuration.
 gitlab_create_self_signed_cert: "true"
@@ -55,3 +55,10 @@ gitlab_email_enabled: "false"
 gitlab_email_from: "gitlab@example.com"
 gitlab_email_display_name: "Gitlab"
 gitlab_email_reply_to: "gitlab@example.com"
+
+# Nginx
+gitlab_nginx_enabled: true
+gitlab_real_ip_trusted_addresses: []
+gitlab_nginx_listen_https: no
+gitlab_nginx_listen_port: {{ 443 if gitlab_nginx_listen_https else 80 }}
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,13 +4,14 @@ gitlab_external_url: "https://gitlab/"
 gitlab_git_data_dir: "/var/opt/gitlab/git-data"
 gitlab_edition: "gitlab-ce"
 gitlab_backup_path: "/var/opt/gitlab/backups"
+gitlab_custom_server_config:
 
-# SSL Configuration.
+# Encryption Configuration.
 gitlab_redirect_http_to_https: "true"
-gitlab_https_certificate: "/etc/gitlab/ssl/gitlab.crt"
-gitlab_https_certificate_key: "/etc/gitlab/ssl/gitlab.key"
+gitlab_https_cert: "/etc/gitlab/ssl/gitlab.crt"
+gitlab_https_key: "/etc/gitlab/ssl/gitlab.key"
 
-# SSL Self-signed Certificate Configuration.
+# Self-signed Certificate Configuration.
 gitlab_create_self_signed_cert: "true"
 gitlab_self_signed_cert_subj: "/C=US/ST=Missouri/L=Saint Louis/O=IT/CN=gitlab"
 
@@ -38,6 +39,12 @@ gitlab_smtp_openssl_verify_mode: "none"
 gitlab_smtp_ca_path: "/etc/ssl/certs"
 gitlab_smtp_ca_file: "/etc/ssl/certs/ca-certificates.crt"
 
+# Nginx
+gitlab_nginx_enabled: true
+gitlab_nginx_real_ip_trusted_addresses:
+gitlab_nginx_listen_https: no
+gitlab_nginx_listen_port: '{{ 443 if gitlab_nginx_listen_https else 80 }}'
+
 # 2-way SSL Client Authentication support.
 gitlab_nginx_ssl_verify_client: ""
 gitlab_nginx_ssl_client_certificate: ""
@@ -55,10 +62,3 @@ gitlab_email_enabled: "false"
 gitlab_email_from: "gitlab@example.com"
 gitlab_email_display_name: "Gitlab"
 gitlab_email_reply_to: "gitlab@example.com"
-
-# Nginx
-gitlab_nginx_enabled: true
-gitlab_real_ip_trusted_addresses: []
-gitlab_nginx_listen_https: no
-gitlab_nginx_listen_port: {{ 443 if gitlab_nginx_listen_https else 80 }}
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,8 +53,8 @@
 
 - name: Create self-signed certificate.
   command: >
-    openssl req -new -nodes -x509 -subj "{{ gitlab_self_signed_cert_subj }}" -days 3650 -keyout {{ gitlab_https_key }} -out {{ gitlab_https_certificate }} -extensions v3_ca
-    creates={{ gitlab_ssl_certificate }}
+    openssl req -new -nodes -x509 -subj "{{ gitlab_self_signed_cert_subj }}" -days 3650 -keyout {{ gitlab_https_key }} -out {{ gitlab_https_cert }} -extensions v3_ca
+    creates={{ gitlab_https_cert }}
   when: gitlab_create_self_signed_cert
 
 - name: Copy GitLab configuration file.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,7 +53,7 @@
 
 - name: Create self-signed certificate.
   command: >
-    openssl req -new -nodes -x509 -subj "{{ gitlab_self_signed_cert_subj }}" -days 3650 -keyout {{ gitlab_ssl_certificate_key }} -out {{ gitlab_ssl_certificate }} -extensions v3_ca
+    openssl req -new -nodes -x509 -subj "{{ gitlab_self_signed_cert_subj }}" -days 3650 -keyout {{ gitlab_https_key }} -out {{ gitlab_https_certificate }} -extensions v3_ca
     creates={{ gitlab_ssl_certificate }}
   when: gitlab_create_self_signed_cert
 

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -11,11 +11,6 @@ gitlab_rails['gitlab_email_display_name'] = "{{ gitlab_email_display_name }}"
 gitlab_rails['gitlab_email_reply_to'] = "{{ gitlab_email_reply_to }}"
 {% endif %}
 
-# Whether to redirect http to https.
-nginx['redirect_http_to_https'] = {{ gitlab_redirect_http_to_https }}
-nginx['ssl_certificate'] = "{{ gitlab_ssl_certificate }}"
-nginx['ssl_certificate_key'] = "{{ gitlab_ssl_certificate_key }}"
-
 # The directory where Git repositories will be stored.
 git_data_dirs({"default" => "{{ gitlab_git_data_dir }}"})
 
@@ -36,11 +31,26 @@ gitlab_rails['ldap_base'] = '{{ gitlab_ldap_base }}'
 
 # GitLab Nginx
 ## See https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/doc/settings/nginx.md
+nginx['listen_https'] = {{ 'true' if gitlab_nginx_enabled == true else 'false' }}
+{% if gitlab_nginx_enabled == true %}
 {% if gitlab_nginx_listen_port is defined %}
 nginx['listen_port'] = "{{ gitlab_nginx_listen_port }}"
 {% endif %}
 {% if gitlab_nginx_listen_https is defined %}
-nginx['listen_https'] = "{{ gitlab_nginx_listen_https }}"
+nginx['listen_https'] = {{ 'true' if gitlab_nginx_listen_https == true else 'false' }}
+{% endif %}
+{% if gitlab_custom_server_config is defined %}
+nginx['custom_gitlab_server_config'] = '{{gitlab_custom_server_config}}'
+{% endif %}
+{% if gitlab_real_ip_trusted_addresses is defined %}
+nginx['real_ip_trusted_addresses'] = ['{{ gitlab_real_ip_trusted_addresses | join("', '") }}']
+{% endif %}
+# Whether to redirect http to https.
+nginx['redirect_http_to_https'] = {{ 'true' if (gitlab_redirect_http_to_https == true) else 'false' }}
+{% if gitlab_https_certificate and gitlab_https_key %}
+nginx['ssl_certificate'] = "{{ gitlab_https_certificate }}"
+nginx['ssl_certificate_key'] = "{{ gitlab_https_certificate_key }}"
+{% endif %}
 {% endif %}
 
 # Use smtp instead of sendmail/postfix

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -33,23 +33,19 @@ gitlab_rails['ldap_base'] = '{{ gitlab_ldap_base }}'
 ## See https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/doc/settings/nginx.md
 nginx['listen_https'] = {{ 'true' if gitlab_nginx_enabled == true else 'false' }}
 {% if gitlab_nginx_enabled == true %}
-{% if gitlab_nginx_listen_port is defined %}
 nginx['listen_port'] = "{{ gitlab_nginx_listen_port }}"
-{% endif %}
-{% if gitlab_nginx_listen_https is defined %}
 nginx['listen_https'] = {{ 'true' if gitlab_nginx_listen_https == true else 'false' }}
+{% if gitlab_custom_server_config %}
+nginx['custom_gitlab_server_config'] = '{{ gitlab_custom_server_config }}'
 {% endif %}
-{% if gitlab_custom_server_config is defined %}
-nginx['custom_gitlab_server_config'] = '{{gitlab_custom_server_config}}'
-{% endif %}
-{% if gitlab_real_ip_trusted_addresses is defined %}
-nginx['real_ip_trusted_addresses'] = ['{{ gitlab_real_ip_trusted_addresses | join("', '") }}']
+{% if gitlab_nginx_real_ip_trusted_addresses %}
+nginx['real_ip_trusted_addresses'] = ['{{ gitlab_nginx_real_ip_trusted_addresses | join("', '") }}']
 {% endif %}
 # Whether to redirect http to https.
 nginx['redirect_http_to_https'] = {{ 'true' if (gitlab_redirect_http_to_https == true) else 'false' }}
-{% if gitlab_https_certificate and gitlab_https_key %}
-nginx['ssl_certificate'] = "{{ gitlab_https_certificate }}"
-nginx['ssl_certificate_key'] = "{{ gitlab_https_certificate_key }}"
+{% if gitlab_https_cert and gitlab_https_key %}
+nginx['ssl_certificate'] = "{{ gitlab_https_cert }}"
+nginx['ssl_certificate_key'] = "{{ gitlab_https_key }}"
 {% endif %}
 {% endif %}
 


### PR DESCRIPTION
Added options:
- `gitlab_custom_server_config` adds a custom server line to nginx config
- `real_ip_trusted_addresses` is a list of trusted proxies
