### PR TITLE
Passthrough GitLab configuration variables 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,62 +17,21 @@ None.
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
-    gitlab_external_url: "https://gitlab/"
+	gitlab_create_self_signed_cert: false
+	
+Toggles GitLab to create self_signed_certificates
+	
+	gitlab_config:
+		gitlab_rails:
+			git_data_dir: "/var/opt/gitlab/git-data"
+			external_url: "https://{{site_name}}/"
+		nginx:
+			enable: false
+		...
 
-The URL at which the GitLab instance will be accessible. This is set as the `external_url` configuration setting in `gitlab.rb`, and if you want to run GitLab on a different port (besides 80/443), you can specify the port here (e.g. `https://gitlab:8443/` for port 8443).
+All variables nested within `gitlab_config` will be passed through to the gitlab-omnibus configuration (`/etc/gitlab/gitlab.rb`).
 
-    gitlab_git_data_dir: "/var/opt/gitlab/git-data"
-
-The `gitlab_git_data_url` is the location where all the Git repositories will be stored. You can use a shared drive or any path on the system.
-
-    # SSL Configuration.
-    gitlab_redirect_http_to_https: "true"
-    gitlab_ssl_certificate: "/etc/gitlab/ssl/gitlab.crt"
-    gitlab_ssl_certificate_key: "/etc/gitlab/ssl/gitlab.key"
-
-GitLab SSL configuration; tells GitLab to redirect normal http requests to https, and the path to the certificate and key (the default values will work for automatic self-signed certificate creation, if set to `true` in the variable below).
-
-    # SSL Self-signed Certificate Configuration.
-    gitlab_create_self_signed_cert: true
-    gitlab_self_signed_cert_subj: "/C=US/ST=Missouri/L=Saint Louis/O=IT/CN=gitlab"
-
-Whether to create a self-signed certificate for serving GitLab over a secure connection. Set `gitlab_self_signed_cert_subj` according to your locality and organization.
-
-    # LDAP Configuration.
-    gitlab_ldap_enabled: "false"
-    gitlab_ldap_host: "example.com"
-    gitlab_ldap_port: "389"
-    gitlab_ldap_uid: "sAMAccountName"
-    gitlab_ldap_method: "plain"
-    gitlab_ldap_bind_dn: "CN=Username,CN=Users,DC=example,DC=com"
-    gitlab_ldap_password: "password"
-    gitlab_ldap_base: "DC=example,DC=com"
-
-GitLab LDAP configuration; if `gitlab_ldap_enabled` is `true`, the rest of the configuration will tell GitLab how to connect to an LDAP server for centralized authentication.
-
-    gitlab_time_zone: "UTC"
-
-Gitlab timezone.
-
-    gitlab_backup_keep_time: "604800"
-
-How long to keep local backups (useful if you don't want backups to fill up your drive!).
-
-    # Email configuration.
-    gitlab_email_enabled: false
-    gitlab_email_from: 'gitlab@example.com'
-    gitlab_email_display_name: 'Gitlab'
-    gitlab_email_reply_to: 'gitlab@example.com'
-
-Gitlab system mail configuration. Disabled by default; set `gitlab_email_enabled` to `true` to enable, and make sure you enter valid from/reply-to values.
-
-    gitlab_nginx_listen_port: 8080
-
-If you are running GitLab behind a reverse proxy, you may want to override the listen port to something else.
-
-    gitlab_nginx_listen_https: false
-
-If you are running GitLab behind a reverse proxy, you may wish to terminate SSL at another proxy server or load balancer
+Please refer to the list of [GitLab options and their defaults](https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/files/gitlab-cookbooks/gitlab/attributes/default.rb)
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,14 +1,25 @@
 ---
 
-gitlab_default_config:
-  git_data_dir: "/var/opt/gitlab/git-data"
-  gitlab_rails:
-    registry_enabled: false
-
 gitlab_create_self_signed_cert: true
 gitlab_self_signed_cert_subj: "/C=US/ST=Missouri/L=Saint Louis/O=IT/CN=gitlab"
 gitlab_self_signed_cert_file: "/etc/gitlab/ssl/gitlab.crt"
 gitlab_self_signed_cert_key_file: "/etc/gitlab/ssl/gitlab.key"
 
 # Probably best to leave this as the default, unless doing testing.
-gitlab_restart_handler_failed_when: 'gitlab_restart.rc != 0'
+gitlab_restart_handler_failed_when: "gitlab_restart.rc != 0"
+
+gitlab_default_config:
+  external_url: "https://gitlab/"
+  git_data_dir: "/var/opt/gitlab/git-data"
+  gitlab_rails:
+    registry_enabled: false
+    time_zone: "UTC"
+    backup_keep_time: "604800"
+    gitlab_email_enabled: false
+    ldap_enabled: false
+  nginx:
+    redirect_http_to_https: true
+    ssl_certificate: "{{ gitlab_self_signed_cert_file }}"
+    ssl_certificate_key: "{{ gitlab_self_signed_cert_key_file }}"
+    listen_port: 8080
+    listen_https: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,36 +1,14 @@
 ---
-# General config.
-gitlab_external_url: "https://gitlab/"
-gitlab_git_data_dir: "/var/opt/gitlab/git-data"
 
-# SSL Configuration.
-gitlab_redirect_http_to_https: "true"
-gitlab_ssl_certificate: "/etc/gitlab/ssl/gitlab.crt"
-gitlab_ssl_certificate_key: "/etc/gitlab/ssl/gitlab.key"
+gitlab_default_config:
+  git_data_dir: "/var/opt/gitlab/git-data"
+  gitlab_rails:
+    registry_enabled: false
 
-# SSL Self-signed Certificate Configuration.
 gitlab_create_self_signed_cert: true
 gitlab_self_signed_cert_subj: "/C=US/ST=Missouri/L=Saint Louis/O=IT/CN=gitlab"
-
-# LDAP Configuration.
-gitlab_ldap_enabled: "false"
-gitlab_ldap_host: "example.com"
-gitlab_ldap_port: "389"
-gitlab_ldap_uid: "sAMAccountName"
-gitlab_ldap_method: "plain"
-gitlab_ldap_bind_dn: "CN=Username,CN=Users,DC=example,DC=com"
-gitlab_ldap_password: "password"
-gitlab_ldap_base: "DC=example,DC=com"
+gitlab_self_signed_cert_file: "/etc/gitlab/ssl/gitlab.crt"
+gitlab_self_signed_cert_key_file: "/etc/gitlab/ssl/gitlab.key"
 
 # Probably best to leave this as the default, unless doing testing.
 gitlab_restart_handler_failed_when: 'gitlab_restart.rc != 0'
-
-# Optional settings.
-gitlab_time_zone: "UTC"
-gitlab_backup_keep_time: "604800"
-
-# Email configuration.
-gitlab_email_enabled: "false"
-gitlab_email_from: 'gitlab@example.com'
-gitlab_email_display_name: 'Gitlab'
-gitlab_email_reply_to: 'gitlab@example.com'

--- a/tasks/_self-signed-certificate.yml
+++ b/tasks/_self-signed-certificate.yml
@@ -1,0 +1,15 @@
+- set_fact: gitlab_config.nginx.ssl_certificate="{{ gitlab_self_signed_cert_file }}"
+- set_fact: gitlab_config.nginx.ssl_certificate_key="{{ gitlab_self_signed_cert_key_file }}"
+
+- name: Create GitLab SSL configuration folder.
+  file:
+    path: "{{ gitlab_self_signed_cert_file | basename }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0700
+
+- name: Create self-signed certificate.
+  command: >
+    openssl req -new -nodes -x509 -subj "{{ gitlab_self_signed_cert_subj }}" -days 3650 -keyout {{ gitlab_self_signed_cert_key_file }} -out {{ gitlab_self_signed_cert_file }} -extensions v3_ca
+    creates={{ gitlab_self_signed_cert_file }}

--- a/tasks/_self-signed-certificate.yml
+++ b/tasks/_self-signed-certificate.yml
@@ -1,9 +1,17 @@
-- set_fact: gitlab_config.nginx.ssl_certificate="{{ gitlab_self_signed_cert_file }}"
-- set_fact: gitlab_config.nginx.ssl_certificate_key="{{ gitlab_self_signed_cert_key_file }}"
+---
+
+- set_fact:
+    _gitlab_config_update:
+      nginx:
+        ssl_certificate: '{{ gitlab_self_signed_cert_file }}'
+        ssl_certificate_key: '{{ gitlab_self_signed_cert_key_file }}'
+
+- set_fact:
+    gitlab_config: '{{ gitlab_config | combine(_gitlab_config_update) }}'
 
 - name: Create GitLab SSL configuration folder.
   file:
-    path: "{{ gitlab_self_signed_cert_file | basename }}"
+    path: "{{ gitlab_self_signed_cert_file[:-(gitlab_self_signed_cert_file | basename | length + 1)] }}"
     state: directory
     owner: root
     group: root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Include OS-specific variables.
   include_vars: "{{ ansible_os_family }}.yml"
 
-- set_fact: gitlab_config="{{ gitlab_config | combine(gitlab_default_config) }}"
+- set_fact: gitlab_config="{{ (gitlab_config | default({})) | combine(gitlab_default_config) }}"
 
 - name: Check if GitLab configuration file already exists.
   stat: path=/etc/gitlab/gitlab.rb

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,8 @@
 - name: Include OS-specific variables.
   include_vars: "{{ ansible_os_family }}.yml"
 
+- set_fact: gitlab_config="{{ gitlab_config | combine(gitlab_default_config) }}"
+
 - name: Check if GitLab configuration file already exists.
   stat: path=/etc/gitlab/gitlab.rb
   register: gitlab_config_file
@@ -40,19 +42,7 @@
     creates=/var/opt/gitlab/bootstrapped
   failed_when: false
 
-- name: Create GitLab SSL configuration folder.
-  file:
-    path: /etc/gitlab/ssl
-    state: directory
-    owner: root
-    group: root
-    mode: 0700
-  when: gitlab_create_self_signed_cert
-
-- name: Create self-signed certificate.
-  command: >
-    openssl req -new -nodes -x509 -subj "{{ gitlab_self_signed_cert_subj }}" -days 3650 -keyout {{ gitlab_ssl_certificate_key }} -out {{ gitlab_ssl_certificate }} -extensions v3_ca
-    creates={{ gitlab_ssl_certificate }}
+- include: _self-signed-certificate.yml
   when: gitlab_create_self_signed_cert
 
 - name: Copy GitLab configuration file.

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -1,44 +1,24 @@
-# The URL through which GitLab will be accessed.
-external_url "{{ gitlab_external_url }}"
-
-# gitlab.yml configuration
-gitlab_rails['time_zone'] = "{{ gitlab_time_zone }}"
-gitlab_rails['backup_keep_time'] = {{ gitlab_backup_keep_time }}
-gitlab_rails['gitlab_email_enabled'] = {{ gitlab_email_enabled }}
-{% if gitlab_email_enabled == "true" %}
-gitlab_rails['gitlab_email_from'] = "{{ gitlab_email_from }}"
-gitlab_rails['gitlab_email_display_name'] = "{{ gitlab_email_display_name }}"
-gitlab_rails['gitlab_email_reply_to'] = "{{ gitlab_email_reply_to }}"
+{% for gitlab_config_category_name, gitlab_config_category in gitlab_config.iteritems() %}
+{% if ((gitlab_config_category == true) or (gitlab_config_category == false)) %}
+{{gitlab_config_category_name}} {{ 'true' if gitlab_config_category == true else 'false' }}
+{% elif gitlab_config_option is number %}
+{{gitlab_config_category_name}} {{gitlab_config_category}}
+{% elif gitlab_config_category is string %}
+{{gitlab_config_category_name}} "{{gitlab_config_category}}"
+{% else %}
+{% for gitlab_config_option_name, gitlab_config_option in gitlab_config_category.iteritems() %}
+{% if ((gitlab_config_option == true) or (gitlab_config_option == false)) %}
+{{gitlab_config_category_name}}['{{gitlab_config_option_name}}'] = {{ 'true' if gitlab_config_option_name == true else 'false'}}
+{% elif gitlab_config_option is number %}
+{{gitlab_config_category_name}}['{{gitlab_config_option_name}}'] = {{gitlab_config_option}}
+{% elif gitlab_config_option is string %}
+{{gitlab_config_category_name}}['{{gitlab_config_option_name}}'] = "{{gitlab_config_option}}"
+{% elif gitlab_config_option is iterable %}
+{{gitlab_config_category_name}}['{{gitlab_config_option_name}}'] = ['{{ gitlab_config_option | join("', '") }}']
 {% endif %}
-
-# Whether to redirect http to https.
-nginx['redirect_http_to_https'] = {{ gitlab_redirect_http_to_https }}
-nginx['ssl_certificate'] = "{{ gitlab_ssl_certificate }}"
-nginx['ssl_certificate_key'] = "{{ gitlab_ssl_certificate_key }}"
-
-# The directory where Git repositories will be stored.
-git_data_dir "{{ gitlab_git_data_dir }}"
-
-# These settings are documented in more detail at
-# https://gitlab.com/gitlab-org/gitlab-ce/blob/master/config/gitlab.yml.example#L118
-gitlab_rails['ldap_enabled'] = {{ gitlab_ldap_enabled }}
-gitlab_rails['ldap_host'] = '{{ gitlab_ldap_host }}'
-gitlab_rails['ldap_port'] = {{ gitlab_ldap_port }}
-gitlab_rails['ldap_uid'] = '{{ gitlab_ldap_uid }}'
-gitlab_rails['ldap_method'] = '{{ gitlab_ldap_method}}' # 'ssl' or 'plain'
-gitlab_rails['ldap_bind_dn'] = '{{ gitlab_ldap_bind_dn }}'
-gitlab_rails['ldap_password'] = '{{ gitlab_ldap_password }}'
-gitlab_rails['ldap_allow_username_or_email_login'] = true
-gitlab_rails['ldap_base'] = '{{ gitlab_ldap_base }}'
-
-# GitLab Nginx
-## See https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/doc/settings/nginx.md
-{% if gitlab_nginx_listen_port is defined %}
-nginx['listen_port'] = "{{ gitlab_nginx_listen_port }}"
+{% endfor %}
 {% endif %}
-{% if gitlab_nginx_listen_https is defined %}
-nginx['listen_https'] = "{{ gitlab_nginx_listen_https }}"
-{% endif %}
+{% endfor %}
 
-# To change other settings, see:
-# https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/README.md#changing-gitlab-yml-settings
+# Find more configuration options: 
+# https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/files/gitlab-cookbooks/gitlab/attributes/default.rb


### PR DESCRIPTION
Looking through the [long list of GitLab configuration options](https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/files/gitlab-cookbooks/gitlab/attributes/default.rb) I wonder if it's a good idea to use a template as configuration file, because the maintenance level is high and/or we'll always be behind GitLabs most recent changes.

I suggest to provide one nested variable `gitlab_config` as interface of this role to map arbitrary GitLab configuration.

**Edit**: #43, #44 and #46 would become obsolete with this changes.
