### PR TITLE
Add ability to define backup directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ The URL at which the GitLab instance will be accessible. This is set as the `ext
 
 The `gitlab_git_data_url` is the location where all the Git repositories will be stored. You can use a shared drive or any path on the system.
 
+    gitlab_backup_path: "/var/opt/gitlab/backups"
+
+The `gitlab_backup_path` is the location where Gitlab backups will be stored.
+
     gitlab_edition: "gitlab-ce"
 
 The edition of GitLab to install. Usually either `gitlab-ce` (Community Edition) or `gitlab-ee` (Enterprise Edition).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 gitlab_external_url: "https://gitlab/"
 gitlab_git_data_dir: "/var/opt/gitlab/git-data"
 gitlab_edition: "gitlab-ce"
+gitlab_backup_path: "/var/opt/gitlab/backups"
 
 # SSL Configuration.
 gitlab_redirect_http_to_https: "true"

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -19,6 +19,9 @@ nginx['ssl_certificate_key'] = "{{ gitlab_ssl_certificate_key }}"
 # The directory where Git repositories will be stored.
 git_data_dirs({"default" => "{{ gitlab_git_data_dir }}"})
 
+# The directory where Gitlab backups will be stored
+gitlab_rails['backup_path'] = "{{ gitlab_backup_path }}"
+
 # These settings are documented in more detail at
 # https://gitlab.com/gitlab-org/gitlab-ce/blob/master/config/gitlab.yml.example#L118
 gitlab_rails['ldap_enabled'] = {{ gitlab_ldap_enabled }}


### PR DESCRIPTION
This PR adds the ability to define a backup directory.

I wanted to alter the default and have it ansible managed seeing as it opens the option to store backups in a dedicated mount which could be interesting for larger installs or less vanilla infrastructure choices.

Less basic backup config is omitted but I may take a stab at it over time.