### PR TITLE
Add environment variables for gitlab_install_repository.sh script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ If you are running GitLab behind a reverse proxy, you may want to override the l
 
 If you are running GitLab behind a reverse proxy, you may wish to terminate SSL at another proxy server or load balancer
 
+    gitlab_install_repo_env:
+      os: ""
+      dist: ""
+
+Packagecloud does not support other than LTS Ubuntu releases. To override os/dist detection, you can set e.g. os="ubuntu" dist="xenial" to enable installation on yakkety.
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,3 +35,6 @@ gitlab_email_enabled: "false"
 gitlab_email_from: "gitlab@example.com"
 gitlab_email_display_name: "Gitlab"
 gitlab_email_reply_to: "gitlab@example.com"
+
+gitlab_install_repo_env:
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,7 @@
   when: (gitlab_file.stat.exists == false)
 
 - name: Install GitLab repository
+  environment: "{{ gitlab_install_repo_env }}"
   command: bash /tmp/gitlab_install_repository.sh
   when: (gitlab_file.stat.exists == false)
 


### PR DESCRIPTION
Hi. I ran into a problem trying to install on Ubuntu 16.10 "yakkety". Packagecloud only has packages for LTS Ubuntu releases. Here is a quick hack to enable providing environment variables for the gitlab_install_repository.sh script to make it possible to override the dist detection.
