### PR TITLE
CentOS 7 minimal doesn’t ship openssl

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,7 @@
     - openssh-server
     - postfix
     - curl
+    - openssl
 
 - name: Download GitLab repository installation script.
   get_url:


### PR DESCRIPTION
On a clean centos box this role will failed as openssl is not installed.