### PR TITLE
Added variable gitlab_ldap_user_filter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Whether to create a self-signed certificate for serving GitLab over a secure con
     gitlab_ldap_bind_dn: "CN=Username,CN=Users,DC=example,DC=com"
     gitlab_ldap_password: "password"
     gitlab_ldap_base: "DC=example,DC=com"
+    gitlab_ldap_user_filter: "ou=gitlab" (optional)
 
 GitLab LDAP configuration; if `gitlab_ldap_enabled` is `true`, the rest of the configuration will tell GitLab how to connect to an LDAP server for centralized authentication.
 

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -33,6 +33,9 @@ gitlab_rails['ldap_bind_dn'] = '{{ gitlab_ldap_bind_dn }}'
 gitlab_rails['ldap_password'] = '{{ gitlab_ldap_password }}'
 gitlab_rails['ldap_allow_username_or_email_login'] = true
 gitlab_rails['ldap_base'] = '{{ gitlab_ldap_base }}'
+{% if gitlab_ldap_user_filter is defined %}
+gitlab_rails['ldap_user_filter'] = '{{ gitlab_ldap_user_filter }}'
+{% endif %}
 
 # GitLab Nginx
 ## See https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/doc/settings/nginx.md


### PR DESCRIPTION
This variabe allows you to apply a user filter which are allowed to log in into GitLab. This parameter is optional. In the exampe every user with the ou=gitlab attribute set is allowed to log in.