### PR TITLE
Add default theme setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ If you are running GitLab behind a reverse proxy, you may wish to terminate SSL 
 
 If you want to enable [2-way SSL Client Authentication](https://docs.gitlab.com/omnibus/settings/nginx.html#enable-2-way-ssl-client-authentication), set `gitlab_nginx_ssl_verify_client` and add a path to the client certificate in `gitlab_nginx_ssl_client_certificate`.
 
+    gitlab_default_theme: 2
+
+If you want to set default theme for all users.
+
 ## Dependencies
 
 None.

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -11,6 +11,9 @@ gitlab_rails['gitlab_email_display_name'] = "{{ gitlab_email_display_name }}"
 gitlab_rails['gitlab_email_reply_to'] = "{{ gitlab_email_reply_to }}"
 {% endif %}
 
+# Default Theme
+gitlab_rails['gitlab_default_theme'] = "{{ gitlab_default_theme | default('2') }}"
+
 # Whether to redirect http to https.
 nginx['redirect_http_to_https'] = {{ gitlab_redirect_http_to_https }}
 nginx['ssl_certificate'] = "{{ gitlab_ssl_certificate }}"


### PR DESCRIPTION
The default theme in Gitlab 10.0 is very ugly. That can be useful to set the default theme.