### PR TITLE
Add prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,20 @@ If you are running GitLab behind a reverse proxy, you may wish to terminate SSL 
 
 If you want to enable [2-way SSL Client Authentication](https://docs.gitlab.com/omnibus/settings/nginx.html#enable-2-way-ssl-client-authentication), set `gitlab_nginx_ssl_verify_client` and add a path to the client certificate in `gitlab_nginx_ssl_client_certificate`.
 
+    gitlab_prometheus_enable: 'true'
+    gitlab_prometheus_monitor_kubernetes: 'true'
+    gitlab_prometheus_username: 'gitlab-prometheus'
+    gitlab_prometheus_uid: ''
+    gitlab_prometheus_gid: ''
+    gitlab_prometheus_shell: '/bin/sh'
+    gitlab_prometheus_home: '/var/opt/gitlab/prometheus'
+    gitlab_prometheus_log_directory:  '/var/log/gitlab/prometheus'
+    gitlab_prometheus_scrape_interval: 15
+    gitlab_prometheus_scrape_timeout: 15
+    gitlab_prometheus_chunk_encoding_version : 2
+
+If you want to set some [https://docs.gitlab.com/ce/administration/monitoring/prometheus/](Prometheusi settings).
+
 ## Dependencies
 
 None.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,18 @@ If you are running GitLab behind a reverse proxy, you may wish to terminate SSL 
 
 If you want to enable [2-way SSL Client Authentication](https://docs.gitlab.com/omnibus/settings/nginx.html#enable-2-way-ssl-client-authentication), set `gitlab_nginx_ssl_verify_client` and add a path to the client certificate in `gitlab_nginx_ssl_client_certificate`.
 
+    gitlab_prometheus_monitoring_enable: 'true'
+
+To completely disable [Gitlab Prometheus](https://docs.gitlab.com/ce/administration/monitoring/prometheus), and all of it's exporters, set to false.
+
+    gitlab_monitor_enable: 'true'
+    gitlab_monitor_log_directory: '/var/log/gitlab/gitlab-monitor'
+    gitlab_monitor_home: '/var/opt/gitlab/gitlab-monitor'
+    gitlab_monitor_listen_address: 'localhost'
+    gitlab_monitor_listen_port: '9168'
+
+[GitLab monitor exporter](https://docs.gitlab.com/ce/administration/monitoring/prometheus/gitlab_monitor_exporter.html) configuration; if `gitlab_monitor_enable` is `true` the rest of the configuration could be set.
+
     gitlab_prometheus_enable: 'true'
     gitlab_prometheus_monitor_kubernetes: 'true'
     gitlab_prometheus_username: 'gitlab-prometheus'
@@ -119,7 +131,7 @@ If you want to enable [2-way SSL Client Authentication](https://docs.gitlab.com/
     gitlab_prometheus_scrape_timeout: 15
     gitlab_prometheus_chunk_encoding_version : 2
 
-If you want to set some [https://docs.gitlab.com/ce/administration/monitoring/prometheus/](Prometheusi settings).
+If you want to set some [https://docs.gitlab.com/ce/administration/monitoring/prometheus/](Prometheus settings).
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,11 @@ To completely disable [Gitlab Prometheus](https://docs.gitlab.com/ce/administrat
     gitlab_prometheus_scrape_timeout: 15
     gitlab_prometheus_chunk_encoding_version : 2
 
-If you want to set some [https://docs.gitlab.com/ce/administration/monitoring/prometheus/](Prometheus settings).
+If you want to set some [Prometheus settings](https://docs.gitlab.com/ce/administration/monitoring/prometheus/) configuration; if `gitlab_prometheus_enable` is set the rest of the configuration could be set.
+
+    gitlab_prometheus_listen_address: 'localhost:9090'
+
+If you want to set the [port Prometheus listen](https://docs.gitlab.com/ce/administration/monitoring/prometheus/#changing-the-port-prometheus-listens-on). Could be useful to change with an IP if you use a platform for analytics and monitoring.
 
 ## Dependencies
 

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -82,6 +82,21 @@ prometheus['scrape_interval'] = "{{ gitlab_prometheus_scrape_interval | default(
 prometheus['scrape_timeout'] = "{{ gitlab_prometheus_scrape_timeout | default(15) }}"
 prometheus['chunk_encoding_version'] = "{{ gitlab_prometheus_chunk_encoding_version | default(2) }}"
 {% endif %}
+{% if gitlab_monitor_enable is defined %}
+
+# Prometheus Gitlab monitor
+# Docs: https://docs.gitlab.com/ce/administration/monitoring/prometheus/gitlab_monitor_exporter.html
+gitlab_monitor['enable'] = "{{ gitlab_monitor_enable | default('true') }}"
+gitlab_monitor['log_directory'] = "{{ gitlab_monitor_log_directory | default('/var/log/gitlab/gitlab-monitor') }}"
+gitlab_monitor['home'] = "{{ gitlab_monitor_home | default('/var/opt/gitlab/gitlab-monitor') }}"
+##! Advanced settings. Should be changed only if absolutely needed.
+gitlab_monitor['listen_address'] = "{{ gitlab_monitor_listen_address | default('localhost') }}"
+gitlab_monitor['listen_port'] = "{{ gitlab_monitor_listen_port | default('9168') }}"
+{% endif %}
+{% if gitlab_prometheus_monitoring_enable is defined %}
+# To completely disable prometheus, and all of it's exporters, set to false
+prometheus_monitoring['enable'] = true
+{% endif %}
 
 # To change other settings, see:
 # https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/README.md#changing-gitlab-yml-settings

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -66,10 +66,12 @@ nginx['ssl_verify_client'] = "{{ gitlab_nginx_ssl_verify_client }}"
 {% if gitlab_nginx_ssl_client_certificate %}
 nginx['ssl_client_certificate'] = "{{ gitlab_nginx_ssl_client_certificate }}"
 {% endif %}
-{% if gitlab_prometheus_enable is defined %}
+{% if gitlab_prometheus_enable is defined or gitlab_prometheus_listen_address is defined %}
 
 # Prometheus
 # Docs: https://docs.gitlab.com/ce/administration/monitoring/prometheus/
+{% endif %}
+{% if gitlab_prometheus_enable is defined %}
 prometheus['enable'] = "{{ gitlab_prometheus_enable | default('true') }}"
 prometheus['monitor_kubernetes'] = "{{ gitlab_prometheus_monitor_kubernetes | default('true') }}"
 prometheus['username'] = "{{ gitlab_prometheus_username | default('gitlab-prometheus') }}"
@@ -81,6 +83,10 @@ prometheus['log_directory'] = "{{ gitlab_prometheus_log_directory | default('/v
 prometheus['scrape_interval'] = "{{ gitlab_prometheus_scrape_interval | default(15) }}"
 prometheus['scrape_timeout'] = "{{ gitlab_prometheus_scrape_timeout | default(15) }}"
 prometheus['chunk_encoding_version'] = "{{ gitlab_prometheus_chunk_encoding_version | default(2) }}"
+{% endif %}
+{% if gitlab_prometheus_listen_address is defined %}
+#! Advanced settings. Should be changed only if absolutely needed.
+prometheus['listen_address'] = "{{ gitlab_prometheus_listen_address | default('localhost:9090') }}"
 {% endif %}
 {% if gitlab_monitor_enable is defined %}
 

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -66,6 +66,22 @@ nginx['ssl_verify_client'] = "{{ gitlab_nginx_ssl_verify_client }}"
 {% if gitlab_nginx_ssl_client_certificate %}
 nginx['ssl_client_certificate'] = "{{ gitlab_nginx_ssl_client_certificate }}"
 {% endif %}
+{% if gitlab_prometheus_enable is defined %}
+
+# Prometheus
+# Docs: https://docs.gitlab.com/ce/administration/monitoring/prometheus/
+prometheus['enable'] = "{{ gitlab_prometheus_enable | default('true') }}"
+prometheus['monitor_kubernetes'] = "{{ gitlab_prometheus_monitor_kubernetes | default('true') }}"
+prometheus['username'] = "{{ gitlab_prometheus_username | default('gitlab-prometheus') }}"
+prometheus['uid'] = "{{ gitlab_prometheus_uid | default('') }}"
+prometheus['gid'] = "{{ gitlab_prometheus_gid | default('') }}"
+prometheus['shell'] = "{{ gitlab_prometheus_shell | default('/bin/sh') }}"
+prometheus['home'] = "{{ gitlab_prometheus_home | default('/var/opt/gitlab/prometheus') }}"
+prometheus['log_directory'] = "{{ gitlab_prometheus_log_directory | default('/var/log/gitlab/prometheus') }}"
+prometheus['scrape_interval'] = "{{ gitlab_prometheus_scrape_interval | default(15) }}"
+prometheus['scrape_timeout'] = "{{ gitlab_prometheus_scrape_timeout | default(15) }}"
+prometheus['chunk_encoding_version'] = "{{ gitlab_prometheus_chunk_encoding_version | default(2) }}"
+{% endif %}
 
 # To change other settings, see:
 # https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/README.md#changing-gitlab-yml-settings


### PR DESCRIPTION
That can be useful to set the Gitlab Prometheus.

I use **Grafana** in order to graph the metrics, and I need to set the `prometheus['listen_address']`. So I decide to add the Prometheus and the Gitlab monitor exporter configuration. In fact the features below:


    gitlab_prometheus_monitoring_enable: 'true'

To completely disable [Gitlab Prometheus](https://docs.gitlab.com/ce/administration/monitoring/prometheus), and all of it's exporters, set to false.

    gitlab_monitor_enable: 'true'
    gitlab_monitor_log_directory: '/var/log/gitlab/gitlab-monitor'
    gitlab_monitor_home: '/var/opt/gitlab/gitlab-monitor'
    gitlab_monitor_listen_address: 'localhost'
    gitlab_monitor_listen_port: '9168'

[GitLab monitor exporter](https://docs.gitlab.com/ce/administration/monitoring/prometheus/gitlab_monitor_exporter.html) configuration; if `gitlab_monitor_enable` is `true` the rest of the configuration could be set.

    gitlab_prometheus_enable: 'true'
    gitlab_prometheus_monitor_kubernetes: 'true'
    gitlab_prometheus_username: 'gitlab-prometheus'
    gitlab_prometheus_uid: 'nil'
    gitlab_prometheus_gid: 'nil'
    gitlab_prometheus_shell: '/bin/sh'
    gitlab_prometheus_home: '/var/opt/gitlab/prometheus'
    gitlab_prometheus_log_directory:  '/var/log/gitlab/prometheus'
    gitlab_prometheus_scrape_interval: 15
    gitlab_prometheus_scrape_timeout: 15
    gitlab_prometheus_chunk_encoding_version : 2

If you want to set some [Prometheus settings](https://docs.gitlab.com/ce/administration/monitoring/prometheus/) configuration; if `gitlab_prometheus_enable` is set the rest of the configuration could be set.

    gitlab_prometheus_listen_address: 'localhost:9090'

If you want to set the [port Prometheus listen](https://docs.gitlab.com/ce/administration/monitoring/prometheus/#changing-the-port-prometheus-listens-on). Could be useful to change with an IP if you use a platform for analytics and monitoring.

 