### PR TITLE
Fix Your git_data_dirs settings are deprecated.

### DIFF
--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -17,7 +17,7 @@ nginx['ssl_certificate'] = "{{ gitlab_ssl_certificate }}"
 nginx['ssl_certificate_key'] = "{{ gitlab_ssl_certificate_key }}"
 
 # The directory where Git repositories will be stored.
-git_data_dirs({"default" => "{{ gitlab_git_data_dir }}"})
+git_data_dirs({"default" => { "path" => "{{ gitlab_git_data_dir }}"} })
 
 # The directory where Gitlab backups will be stored
 gitlab_rails['backup_path'] = "{{ gitlab_backup_path }}"


### PR DESCRIPTION
I suggest this minor modification to avoid the deprecation below:

```
Your git_data_dirs settings are deprecated.
Please update it to the following:

git_data_dirs({
  "default": {
    "path": "/var/opt/gitlab/git-data"
  }
})

Please refer to https://docs.gitlab.com/omnibus/settings/configuration.html#storing-git-data-in-an-alternative-directory for updated documentation.
```
