### PR TITLE
Add packages dependencies facility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ If you are running GitLab behind a reverse proxy, you may wish to terminate SSL 
 
 If you want to enable [2-way SSL Client Authentication](https://docs.gitlab.com/omnibus/settings/nginx.html#enable-2-way-ssl-client-authentication), set `gitlab_nginx_ssl_verify_client` and add a path to the client certificate in `gitlab_nginx_ssl_client_certificate`.
 
+    gitlab_packages_dependencies:
+      - openssh-server
+      - postfix
+      - curl
+      - openssl
+      - tzdata
+
+If you want to add or remove some packages dependencies.
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,12 @@ gitlab_edition: "gitlab-ce"
 gitlab_version: ''
 gitlab_backup_path: "/var/opt/gitlab/backups"
 gitlab_config_template: "gitlab.rb.j2"
+gitlab_packages_dependencies:
+  - openssh-server
+  - postfix
+  - curl
+  - openssl
+  - tzdata
 
 # SSL Configuration.
 gitlab_redirect_http_to_https: "true"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,11 +14,7 @@
 - name: Install GitLab dependencies.
   package: name={{ item }} state=present
   with_items:
-    - openssh-server
-    - postfix
-    - curl
-    - openssl
-    - tzdata
+    - "{{ gitlab_packages_dependencies }}"
 
 - name: Download GitLab repository installation script.
   get_url:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,9 +12,8 @@
 
 # Install GitLab and its dependencies.
 - name: Install GitLab dependencies.
-  package: name={{ item }} state=present
-  with_items:
-    - "{{ gitlab_packages_dependencies }}"
+  package: name={{ item }} state=installed
+  with_items: "{{ gitlab_packages_dependencies }}"
 
 - name: Download GitLab repository installation script.
   get_url:


### PR DESCRIPTION
In my case we use _exim_ instead of _postfix_, and I need to avoid the Ansible role to replace the mail sender.

So I suggest to add the packages dependencies as a default variable to be able to tweak it.