### PR TITLE
Add feature to upload backup to s3 bucket

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,14 @@ gitlab_edition: "gitlab-ce"
 gitlab_version: ''
 gitlab_backup_path: "/var/opt/gitlab/backups"
 
+#Cloud backup.
+gitlab_cloud_backup_provider: ''
+gitlab_aws_instance_profile: 'true'
+gitlab_aws_instance_region: ''
+gitlab_aws_s3_bucket: ''
+gitlab_aws_access_key_id: ''
+gitlab_aws_secret_access_key: ''
+
 # SSL Configuration.
 gitlab_redirect_http_to_https: "true"
 gitlab_ssl_certificate: "/etc/gitlab/ssl/gitlab.crt"

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -21,6 +21,25 @@ git_data_dirs({"default" => "{{ gitlab_git_data_dir }}"})
 
 # The directory where Gitlab backups will be stored
 gitlab_rails['backup_path'] = "{{ gitlab_backup_path }}"
+{% if gitlab_cloud_backup_provider == "aws" %}
+{% if gitlab_aws_instance_profile == "true" %}
+gitlab_rails['backup_upload_connection'] = {
+'provider' => 'AWS',
+'region' => '{{ gitlab_aws_instance_region }}',
+'use_iam_profile' => true
+}
+{% else %}
+gitlab_rails['backup_upload_connection'] = {
+'provider' => 'AWS',
+'region' => '{{ gitlab_aws_instance_region }}',
+'aws_access_key_id' =>  '{{ gitlab_aws_access_key_id }}',
+'aws_secret_access_key' => '{{ gitlab_aws_secret_access_key }}'
+}
+{% endif %}
+gitlab_rails['backup_upload_remote_directory'] = '{{ gitlab_aws_s3_bucket }}'
+{% endif %}
+
+
 
 # These settings are documented in more detail at
 # https://gitlab.com/gitlab-org/gitlab-ce/blob/master/config/gitlab.yml.example#L118


### PR DESCRIPTION
It will allow backup to be uploaded to AWS S3 bucket. Use of aws ec2 instance profile is kept as preferred (default) option.