### PR TITLE
Add possibility to add gitlab.rb parameters that are not templated

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,21 @@ If you are running GitLab behind a reverse proxy, you may wish to terminate SSL 
 
 If you want to enable [2-way SSL Client Authentication](https://docs.gitlab.com/omnibus/settings/nginx.html#enable-2-way-ssl-client-authentication), set `gitlab_nginx_ssl_verify_client` and add a path to the client certificate in `gitlab_nginx_ssl_client_certificate`.
 
+As this module does not contain all parameters of the `gitlab.rb` configuration file, you may want to add more parameters than those provided in this module.
+You can use `gitlab_other_parameters` to add any parameter missing in this module.
+
+    gitlab_other_parameters:
+      "gitlab_rails['omniauth_enabled']": "true"
+      "gitlab_rails['omniauth_external_providers']": "['google_oauth2']"
+      "gitlab_rails['omniauth_providers']": "[
+          {
+            'name' => 'google_oauth2',
+            'app_id' => '{{ google_auth_app_id }}',
+            'app_secret' => '{{ google_auth_app_secret }}',
+            'args' => { 'access_type' => 'offline', 'approval_prompt' => '' }
+          }
+        ]"
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,3 +56,6 @@ gitlab_email_enabled: "false"
 gitlab_email_from: "gitlab@example.com"
 gitlab_email_display_name: "Gitlab"
 gitlab_email_reply_to: "gitlab@example.com"
+
+# Other parameters
+gitlab_other_parameters: {}

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -69,3 +69,7 @@ nginx['ssl_client_certificate'] = "{{ gitlab_nginx_ssl_client_certificate }}"
 
 # To change other settings, see:
 # https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/README.md#changing-gitlab-yml-settings
+
+{% for key,value in gitlab_other_parameters.items() %}
+{{ key }} = {{ value|safe }}
+{% endfor %}


### PR DESCRIPTION
Possibility to add parameters not managed by the present template using dict `gitlab_other_parameters`

Example
```
gitlab_other_parameters:
      "gitlab_rails['omniauth_enabled']": "true"
      "gitlab_rails['omniauth_external_providers']": "['google_oauth2']"
      "gitlab_rails['omniauth_providers']": "[
          {
            'name' => 'google_oauth2',
            'app_id' => '{{ google_auth_app_id }}',
            'app_secret' => '{{ google_auth_app_secret }}',
            'args' => { 'access_type' => 'offline', 'approval_prompt' => '' }
          }
        ]"
```