### PR TITLE
Feature/cutom template path

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,6 @@ gitlab_edition: "gitlab-ce"
 gitlab_version: ''
 gitlab_backup_path: "/var/opt/gitlab/backups"
 gitlab_config_template: "gitlab.rb.j2"
-gitlab_config_template_path: "templates/gitlab.rb.j2"
 
 # SSL Configuration.
 gitlab_redirect_http_to_https: "true"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ gitlab_edition: "gitlab-ce"
 gitlab_version: ''
 gitlab_backup_path: "/var/opt/gitlab/backups"
 gitlab_config_template: "gitlab.rb.j2"
+gitlab_config_template_path: "templates/gitlab.rb.j2"
 
 # SSL Configuration.
 gitlab_redirect_http_to_https: "true"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -75,4 +75,5 @@
       with_first_found:
        - files:
          - "{{ gitlab_config_template_path }}"
+         - gitlab.rb.j2
   notify: restart gitlab

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -67,9 +67,12 @@
 
 - name: Copy GitLab configuration file.
   template:
-    src: "{{ gitlab_config_template }}"
-    dest: /etc/gitlab/gitlab.rb
-    owner: root
-    group: root
-    mode: 0600
+      src: "{{ item }}"
+      dest: /etc/gitlab/gitlab.rb
+      owner: root
+      group: root
+      mode: 0600
+      with_first_found:
+       - files:
+         - "{{ gitlab_config_template_path }}"
   notify: restart gitlab


### PR DESCRIPTION
PR #89: Allow custom gitlab.rb template using gitlab_config_template … does not allow using custom path. This will allow user to use custom path for the gitlab template.