### PR TITLE
added option gitlab_custom_server_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,16 @@ If you are running GitLab behind a reverse proxy, you may wish to terminate SSL 
 
 If you want to enable [2-way SSL Client Authentication](https://docs.gitlab.com/omnibus/settings/nginx.html#enable-2-way-ssl-client-authentication), set `gitlab_nginx_ssl_verify_client` and add a path to the client certificate in `gitlab_nginx_ssl_client_certificate`.
 
+If you want to insert custom NGINX settings into the GitLab server block
+
+   gitlab_custom_server_config: |
+     location /users/sign_in {
+        allow 1.2.3.4;
+        deny all;
+        proxy_pass  http://gitlab-workhorse;
+     }
+
+
 ## Dependencies
 
 None.

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -67,5 +67,8 @@ nginx['ssl_verify_client'] = "{{ gitlab_nginx_ssl_verify_client }}"
 nginx['ssl_client_certificate'] = "{{ gitlab_nginx_ssl_client_certificate }}"
 {% endif %}
 
+# Inserting custom NGINX settings into the GitLab server block
+nginx['custom_gitlab_server_config'] ="{{ gitlab_custom_server_config | replace('\n', '\\n') }}"
+
 # To change other settings, see:
 # https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/README.md#changing-gitlab-yml-settings


### PR DESCRIPTION
That feature is very useful. For example, it helps to restrict access to specific parts of the GitLab application.