### PR TITLE
Added some conditionals to the gitlab.rb template to allow for unauthenticated SMTP - 2

### DIFF
--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -52,10 +52,16 @@ nginx['listen_https'] = {{ gitlab_nginx_listen_https }}
 gitlab_rails['smtp_enable'] = {{ gitlab_smtp_enable }}
 gitlab_rails['smtp_address'] = '{{ gitlab_smtp_address }}'
 gitlab_rails['smtp_port'] = {{ gitlab_smtp_port }}
+{% if gitlab_smtp_user_name %}
 gitlab_rails['smtp_user_name'] = '{{ gitlab_smtp_user_name }}'
+{% endif %}
+{% if gitlab_smtp_password %}
 gitlab_rails['smtp_password'] = '{{ gitlab_smtp_password }}'
+{% endif %}
 gitlab_rails['smtp_domain'] = '{{ gitlab_smtp_domain }}'
+{% if gitlab_smtp_authentication %}
 gitlab_rails['smtp_authentication'] = '{{ gitlab_smtp_authentication }}'
+{% endif %}
 gitlab_rails['smtp_enable_starttls_auto'] = {{ gitlab_smtp_enable_starttls_auto }}
 gitlab_rails['smtp_tls'] = {{ gitlab_smtp_tls }}
 gitlab_rails['smtp_openssl_verify_mode'] = '{{ gitlab_smtp_openssl_verify_mode }}'


### PR DESCRIPTION
Hi,

Gitlab requires the `smtp_authentication`, `smtp_user_name`, and `smtp_password` variables in gitlab.rb to be unset in order to use unauthenticated SMTP. This adds jinja checks for these values and does not set them if they are empty.

In the case of the smtp_authentication = false, you have to remove the smtp_user_name and smtp_password, (well-known issue of Gitlab configuration).

Source : https://gitlab.com/gitlab-org/omnibus-gitlab/issues/325