### PR TITLE
Remove optional postfix dependency

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,6 @@
   package: name={{ item }} state=present
   with_items:
     - openssh-server
-    - postfix
     - curl
     - openssl
     - tzdata


### PR DESCRIPTION
@geerlingguy This is the same idea as #86 but simpler, there's no need to make the dependencies a variable because there are just ones listed by Gitlab as necessary. But as stated in #86 postfix is optional and your role doesn't configure it. Since Gitlab can use direct SMTP or another sendmail option that should just simply be left to the users playbook to configure. If the need other dependencies then those should be other roles or part of the playbook.

I'm in the same situation as the guy in #86 we use nullmailer and have a role defined which sets it up and this role conflicts right now.