### PR TITLE
Configure container registry

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 # General config.
 gitlab_external_url: "https://gitlab/"
+gitlab_registry_external_url: "https://registry/"
 gitlab_git_data_dir: "/var/opt/gitlab/git-data"
 gitlab_edition: "gitlab-ce"
 gitlab_version: ''
@@ -11,10 +12,14 @@ gitlab_config_template: "gitlab.rb.j2"
 gitlab_redirect_http_to_https: "true"
 gitlab_ssl_certificate: "/etc/gitlab/ssl/gitlab.crt"
 gitlab_ssl_certificate_key: "/etc/gitlab/ssl/gitlab.key"
+gitlab_registry_ssl_certificate: "/etc/gitlab/ssl/registry.crt"
+gitlab_registry_ssl_certificate_key: "/etc/gitlab/ssl/registry.key"
 
 # SSL Self-signed Certificate Configuration.
 gitlab_create_self_signed_cert: "true"
 gitlab_self_signed_cert_subj: "/C=US/ST=Missouri/L=Saint Louis/O=IT/CN=gitlab"
+gitlab_registry_create_self_signed_cert: "true"
+gitlab_registry_self_signed_cert_subj: "/C=US/ST=Missouri/L=Saint Louis/O=IT/CN=registry"
 
 # LDAP Configuration.
 gitlab_ldap_enabled: "false"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,14 +57,21 @@
     owner: root
     group: root
     mode: 0700
-  when: gitlab_create_self_signed_cert
+  when: (gitlab_create_self_signed_cert or gitlab_registry_create_self_signed_cert)
 
-- name: Create self-signed certificate.
+- name: Create self-signed gitlab certificate.
   command: >
     openssl req -new -nodes -x509 -subj "{{ gitlab_self_signed_cert_subj }}"
     -days 3650 -keyout {{ gitlab_ssl_certificate_key }} -out {{ gitlab_ssl_certificate }} -extensions v3_ca
     creates={{ gitlab_ssl_certificate }}
   when: gitlab_create_self_signed_cert
+
+- name: Create self-signed registry certificate.
+  command: >
+    openssl req -new -nodes -x509 -subj "{{ gitlab_registry_self_signed_cert_subj }}"
+    -days 3650 -keyout {{ gitlab_registry_ssl_certificate_key }} -out {{ gitlab_registry_ssl_certificate }} -extensions v3_ca
+    creates={{ gitlab_registry_ssl_certificate }}
+  when: gitlab_registry_create_self_signed_cert
 
 - name: Copy GitLab configuration file.
   template:

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -1,6 +1,13 @@
 # The URL through which GitLab will be accessed.
 external_url "{{ gitlab_external_url }}"
 
+# The URL through which GitLab Registry will be accessed.
+{% if gitlab_registry_external_url is defined %}
+registry_external_url "{{ gitlab_registry_external_url }}"
+registry_nginx['ssl_certificate'] = "{{ gitlab_registry_ssl_certificate }}"
+registry_nginx['ssl_certificate_key'] = "{{ gitlab_registry_ssl_certificate_key }}"
+{% endif %}
+
 # gitlab.yml configuration
 gitlab_rails['time_zone'] = "{{ gitlab_time_zone }}"
 gitlab_rails['backup_keep_time'] = {{ gitlab_backup_keep_time }}


### PR DESCRIPTION
The current role doesn't configure the container registry service included with GitLab. This is an initial modification that works for my setup. Please review and provide feedback to meet your requirements to be merged if you like the modification.