### PR TITLE
Add LDAP CA file option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,7 +25,7 @@ gitlab_ldap_method: "plain"
 gitlab_ldap_bind_dn: "CN=Username,CN=Users,DC=example,DC=com"
 gitlab_ldap_password: "password"
 gitlab_ldap_base: "DC=example,DC=com"
-gitlab_ca_cert: ''
+gitlab_ca_file: ''
 
 # SMTP Configuration
 gitlab_smtp_enable: "false"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,7 @@ gitlab_ldap_method: "plain"
 gitlab_ldap_bind_dn: "CN=Username,CN=Users,DC=example,DC=com"
 gitlab_ldap_password: "password"
 gitlab_ldap_base: "DC=example,DC=com"
+gitlab_ca_cert: ''
 
 # SMTP Configuration
 gitlab_smtp_enable: "false"

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -36,7 +36,7 @@ gitlab_rails['ldap_bind_dn'] = '{{ gitlab_ldap_bind_dn }}'
 gitlab_rails['ldap_password'] = '{{ gitlab_ldap_password }}'
 gitlab_rails['ldap_allow_username_or_email_login'] = true
 gitlab_rails['ldap_base'] = '{{ gitlab_ldap_base }}'
-gitlab_rails['ca_cert'] = '{{ gitlab_ca_cert }}'
+gitlab_rails['ca_file'] = '{{ gitlab_ca_file }}'
 
 # GitLab Nginx
 ## See https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/doc/settings/nginx.md

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -36,6 +36,7 @@ gitlab_rails['ldap_bind_dn'] = '{{ gitlab_ldap_bind_dn }}'
 gitlab_rails['ldap_password'] = '{{ gitlab_ldap_password }}'
 gitlab_rails['ldap_allow_username_or_email_login'] = true
 gitlab_rails['ldap_base'] = '{{ gitlab_ldap_base }}'
+gitlab_rails['ca_file'] = '{{ gitlab_ca_file }}'
 
 # GitLab Nginx
 ## See https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/doc/settings/nginx.md

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -36,7 +36,7 @@ gitlab_rails['ldap_bind_dn'] = '{{ gitlab_ldap_bind_dn }}'
 gitlab_rails['ldap_password'] = '{{ gitlab_ldap_password }}'
 gitlab_rails['ldap_allow_username_or_email_login'] = true
 gitlab_rails['ldap_base'] = '{{ gitlab_ldap_base }}'
-gitlab_rails['ca_file'] = '{{ gitlab_ca_file }}'
+gitlab_rails['ca_cert'] = '{{ gitlab_ca_cert }}'
 
 # GitLab Nginx
 ## See https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/doc/settings/nginx.md


### PR DESCRIPTION
This option is useful for LDAP certs issued by an internal CA, which show up as self-signed certs when GitLab tries to validate them. We need to make GitLab trust the CA cert(s).