### PR TITLE
Add a key to enable or disable Grafana

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ If you want to enable [2-way SSL Client Authentication](https://docs.gitlab.com/
 
 GitLab includes a number of themes, and you can set the default for all users with this variable. See [the included GitLab themes to choose a default](https://github.com/gitlabhq/gitlabhq/blob/master/config/gitlab.yml.example#L79-L85).
 
+    gitlab_grafana_enable: "true"
+Gitlab includes a Grafana server to monitor its own metrics. If you have your own Grafana server, you can disable this one.
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,6 +44,9 @@ gitlab_smtp_ca_file: "/etc/ssl/certs/ca-certificates.crt"
 gitlab_nginx_ssl_verify_client: ""
 gitlab_nginx_ssl_client_certificate: ""
 
+# Grafana
+gitlab_grafana_enable: "true"
+
 # Probably best to leave this as the default, unless doing testing.
 gitlab_restart_handler_failed_when: 'gitlab_restart.rc != 0'
 

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -70,5 +70,8 @@ nginx['ssl_verify_client'] = "{{ gitlab_nginx_ssl_verify_client }}"
 nginx['ssl_client_certificate'] = "{{ gitlab_nginx_ssl_client_certificate }}"
 {% endif %}
 
+# Gitlab Grafana
+grafana['enable'] = {{ gitlab_grafana_enable }}
+
 # To change other settings, see:
 # https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/README.md#changing-gitlab-yml-settings


### PR DESCRIPTION
Grafana is enabled by default which is consuming useless ressources for those already running their own Grafana instance.