### PR TITLE
Apply Gitlab application settings

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,10 +10,11 @@ gitlab_config_template: "gitlab.rb.j2"
 # Application Settings
 # Add to true if you want to apply application settings
 # using the gitlab-runner command
-gitlab_apply_application_settings: false 
+gitlab_apply_application_settings: false
 
 # These reflect settings directly applied using gitlab-runner
-# keep in mind that all values (also "true"/"false") needs to be in string format because
+# keep in mind that all values (also "true"/"false")
+# needs to be in string format because
 # they are applied with ansible command
 # inspired by https://gitlab.com/gitlab-org/omnibus-gitlab/issues/2837
 gitlab_application_settings: {}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,10 @@ gitlab_version: ''
 gitlab_backup_path: "/var/opt/gitlab/backups"
 gitlab_config_template: "gitlab.rb.j2"
 
+# Security
+# inspired by https://gitlab.com/gitlab-org/omnibus-gitlab/issues/2837
+gitlab_signup_enabled: true 
+
 # SSL Configuration.
 gitlab_redirect_http_to_https: "true"
 gitlab_ssl_certificate: "/etc/gitlab/ssl/gitlab.crt"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,9 +7,16 @@ gitlab_version: ''
 gitlab_backup_path: "/var/opt/gitlab/backups"
 gitlab_config_template: "gitlab.rb.j2"
 
-# Security
+# Application Settings
+# Add to true if you want to apply application settings
+# using the gitlab-runner command
+gitlab_apply_application_settings: false 
+
+# These reflect settings directly applied using gitlab-runner
+# keep in mind that all values (also "true"/"false") needs to be in string format because
+# they are applied with ansible command
 # inspired by https://gitlab.com/gitlab-org/omnibus-gitlab/issues/2837
-gitlab_signup_enabled: true 
+gitlab_application_settings: {}
 
 # SSL Configuration.
 gitlab_redirect_http_to_https: "true"

--- a/tasks/gitlab-application-settings.yml
+++ b/tasks/gitlab-application-settings.yml
@@ -1,3 +1,7 @@
+- name: Get Application settings using rails runner
+  command: gitlab-rails runner 'puts ApplicationSetting.last.to_json'
+  register: gitlab_application_settings
+
 - name: Disable Account signup
   command: gitlab-rails runner 'ApplicationSetting.last.update_attributes(signup_enabled: false)'
   when: gitlab_signup_enabled == false

--- a/tasks/gitlab-application-settings.yml
+++ b/tasks/gitlab-application-settings.yml
@@ -1,0 +1,3 @@
+- name: Disable Account signup
+  command: gitlab-rails runner 'ApplicationSetting.last.update_attributes(signup_enabled: false)'
+  when: gitlab_signup_enabled == false

--- a/tasks/gitlab-application-settings.yml
+++ b/tasks/gitlab-application-settings.yml
@@ -1,11 +1,29 @@
-- name: Get Application settings using rails runner
+# this moves boolean var content to string in jinja to make 
+# the wanted gitlab_application_settings in boolean usable in rails
+# inspired by:
+# http://rickalm.blogspot.com/2018/08/testing-for-data-types-in-jinja.html
+- name: Move boolean values to lowerized strings to be usable in rails
+  set_fact:
+    ___gitlab_application_settings: |
+      {% if item.value is sameas true or item.value is sameas false %}
+      {{ ___gitlab_application_settings|default({})|combine({item.key:item.value|string|lower}) }}
+      {% else %}
+      {{ ___gitlab_application_settings|default({})|combine({item.key:item.value}) }}
+      {% endif %}
+  with_dict:
+    "{{ gitlab_application_settings }}"
+
+- name: Get Application settings using the gitlab-rails runner command
   command: gitlab-rails runner 'puts ApplicationSetting.last.to_json'
   changed_when: false
-  register: gitlab_application_settings_raw
+  register: __gitlab_application_settings
 
-- set_fact:
-    gitlab_application_settings: "{{ gitlab_application_settings_raw.stdout | from_json }}"
+- name: Convert output from gitlab-rails runner command to dict
+  set_fact:
+    _gitlab_application_settings: "{{ __gitlab_application_settings.stdout | from_json }}"
 
-- name: Disable Account signup
-  command: "gitlab-rails runner 'ApplicationSetting.last.update_attributes(signup_enabled: false)'"
-  when: gitlab_signup_enabled == false and gitlab_application_settings.signup_enabled
+- name: "Apply application setting {{ item.key }}"
+  command: "gitlab-rails runner 'ApplicationSetting.last.update_attributes({{ item.key}}: {{ ___gitlab_application_settings[item.key] }})'"
+  when: _gitlab_application_settings[item.key] != gitlab_application_settings[item.key]
+  with_dict:
+    "{{ gitlab_application_settings }}"

--- a/tasks/gitlab-application-settings.yml
+++ b/tasks/gitlab-application-settings.yml
@@ -1,4 +1,5 @@
-# this moves boolean var content to string in jinja to make 
+---
+# this moves boolean var content to string in jinja to make
 # the wanted gitlab_application_settings in boolean usable in rails
 # inspired by:
 # http://rickalm.blogspot.com/2018/08/testing-for-data-types-in-jinja.html
@@ -23,7 +24,7 @@
     _gitlab_application_settings: "{{ __gitlab_application_settings.stdout | from_json }}"
 
 - name: "Apply application setting {{ item.key }}"
-  command: "gitlab-rails runner 'ApplicationSetting.last.update_attributes({{ item.key}}: {{ ___gitlab_application_settings[item.key] }})'"
+  command: "gitlab-rails runner 'ApplicationSetting.last.update_attributes({{ item.key }}: {{ ___gitlab_application_settings[item.key] }})'"
   when: _gitlab_application_settings[item.key] != gitlab_application_settings[item.key]
   with_dict:
     "{{ gitlab_application_settings }}"

--- a/tasks/gitlab-application-settings.yml
+++ b/tasks/gitlab-application-settings.yml
@@ -1,7 +1,11 @@
 - name: Get Application settings using rails runner
   command: gitlab-rails runner 'puts ApplicationSetting.last.to_json'
-  register: gitlab_application_settings
+  changed_when: false
+  register: gitlab_application_settings_raw
+
+- set_fact:
+    gitlab_application_settings: "{{ gitlab_application_settings_raw.stdout | from_json }}"
 
 - name: Disable Account signup
-  command: gitlab-rails runner 'ApplicationSetting.last.update_attributes(signup_enabled: false)'
-  when: gitlab_signup_enabled == false
+  command: "gitlab-rails runner 'ApplicationSetting.last.update_attributes(signup_enabled: false)'"
+  when: gitlab_signup_enabled == false and gitlab_application_settings.signup_enabled

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -76,5 +76,4 @@
   notify: restart gitlab
 
 - name: Disable Account signup
-  import_tasks: "gitlab-application-settings.yml"
-  when: gitlab_signup_enabled == false
+  import_tasks: gitlab-application-settings.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -75,5 +75,8 @@
     mode: 0600
   notify: restart gitlab
 
+- name: Force restart handler before applying application settings
+  meta: flush_handlers
+
 - name: Disable Account signup
   import_tasks: gitlab-application-settings.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -78,5 +78,6 @@
 - name: Force restart handler before applying application settings
   meta: flush_handlers
 
-- name: Disable Account signup
+- name: Apply gitlab application settings
   import_tasks: gitlab-application-settings.yml
+  when: gitlab_apply_application_settings

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -74,3 +74,7 @@
     group: root
     mode: 0600
   notify: restart gitlab
+
+- name: Disable Account signup
+  import_tasks: "gitlab-application-settings.yml"
+  when: gitlab_signup_enabled == false


### PR DESCRIPTION
This pull request makes it possible to apply application settings within gitlab role.

It ships with 2 new parameters in `defaults.yml`:

`gitlab_apply_applications_settings`: on/off feature to apply settings => default: `false`
`gitlab_application_settings`: a dictionary of the application settings => default: `{}`

All settings are only applied when neccessary. This is done
by first fetching the current settings using gitlab-rails runner
and return them in json format.

To lookup all possible application settings have a look
at the command that fetches the possible settings.

A convenient step is added to transform python boolean
in to string lowercase values that can be used when
new settings are applied using the RoR ActiveRecord.update method.

Note: Both commands, fetch application settings and apply a setting take some time.