### PR TITLE
Add ldap_allow_username_or_email_login variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Whether to create a self-signed certificate for serving GitLab over a secure con
     gitlab_ldap_bind_dn: "CN=Username,CN=Users,DC=example,DC=com"
     gitlab_ldap_password: "password"
     gitlab_ldap_base: "DC=example,DC=com"
+    gitlab_ldap_allow_username_or_email_login: "true"
 
 GitLab LDAP configuration; if `gitlab_ldap_enabled` is `true`, the rest of the configuration will tell GitLab how to connect to an LDAP server for centralized authentication.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,7 @@ gitlab_ldap_method: "plain"
 gitlab_ldap_bind_dn: "CN=Username,CN=Users,DC=example,DC=com"
 gitlab_ldap_password: "password"
 gitlab_ldap_base: "DC=example,DC=com"
+gitlab_ldap_allow_username_or_email_login: "true"
 
 # SMTP Configuration
 gitlab_smtp_enable: "false"

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -34,7 +34,7 @@ gitlab_rails['ldap_uid'] = '{{ gitlab_ldap_uid }}'
 gitlab_rails['ldap_method'] = '{{ gitlab_ldap_method}}' # 'ssl' or 'plain'
 gitlab_rails['ldap_bind_dn'] = '{{ gitlab_ldap_bind_dn }}'
 gitlab_rails['ldap_password'] = '{{ gitlab_ldap_password }}'
-gitlab_rails['ldap_allow_username_or_email_login'] = true
+gitlab_rails['ldap_allow_username_or_email_login'] = '{{ gitlab_ldap_allow_username_or_email_login }}'
 gitlab_rails['ldap_base'] = '{{ gitlab_ldap_base }}'
 
 # GitLab Nginx


### PR DESCRIPTION
This variable controls the username format used for login against
LDAP. The default 'true' requires the @domain.tld suffix. Setting
this to 'false' allows logins without that suffix.