### PR TITLE
allow to disable smtp authentication

### DIFF
--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -52,10 +52,12 @@ nginx['listen_https'] = {{ gitlab_nginx_listen_https }}
 gitlab_rails['smtp_enable'] = {{ gitlab_smtp_enable }}
 gitlab_rails['smtp_address'] = '{{ gitlab_smtp_address }}'
 gitlab_rails['smtp_port'] = {{ gitlab_smtp_port }}
+gitlab_rails['smtp_domain'] = '{{ gitlab_smtp_domain }}'
+{% if gitlab_smtp_authentication != 'disabled' %}
 gitlab_rails['smtp_user_name'] = '{{ gitlab_smtp_user_name }}'
 gitlab_rails['smtp_password'] = '{{ gitlab_smtp_password }}'
-gitlab_rails['smtp_domain'] = '{{ gitlab_smtp_domain }}'
 gitlab_rails['smtp_authentication'] = '{{ gitlab_smtp_authentication }}'
+{% endif %}
 gitlab_rails['smtp_enable_starttls_auto'] = {{ gitlab_smtp_enable_starttls_auto }}
 gitlab_rails['smtp_tls'] = {{ gitlab_smtp_tls }}
 gitlab_rails['smtp_openssl_verify_mode'] = '{{ gitlab_smtp_openssl_verify_mode }}'


### PR DESCRIPTION
setting variable `gitlab_smtp_authentication: "disabled"` will allow gitlab to use a smtp server without smtp authentication.