### PR TITLE
Add an async/poll

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,6 +48,8 @@
   package:
     name: "{{ gitlab_package_name | default(gitlab_edition) }}"
     state: present
+  async: 300
+  poll: 5
   when: not gitlab_file.stat.exists
 
 # Start and configure GitLab. Sometimes the first run fails, but after that,


### PR DESCRIPTION
On install gitlab takes a while and ssh connections can time out in some network environments. This adds a poll to the install command to try and ensure things don't time out during initial install