### PR TITLE
Cast variables to boolean to fix CONDITIONAL_BARE_VARS deprecation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -62,14 +62,14 @@
     owner: root
     group: root
     mode: 0700
-  when: gitlab_create_self_signed_cert
+  when: gitlab_create_self_signed_cert | bool
 
 - name: Create self-signed certificate.
   command: >
     openssl req -new -nodes -x509 -subj "{{ gitlab_self_signed_cert_subj }}"
     -days 3650 -keyout {{ gitlab_ssl_certificate_key }} -out {{ gitlab_ssl_certificate }} -extensions v3_ca
     creates={{ gitlab_ssl_certificate }}
-  when: gitlab_create_self_signed_cert
+  when: gitlab_create_self_signed_cert | bool
 
 - name: Copy GitLab configuration file.
   template:


### PR DESCRIPTION
This pull request adds the `| bool` filter to some variables to fix the following deprecation warning:
> [DEPRECATION WARNING]: evaluating true as a bare variable, this behaviour will 
go away and you might need to add |bool to the expression in the future. Also 
see CONDITIONAL_BARE_VARS configuration toggle.. This feature will be removed 
in version 2.12. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.