### PR TITLE
Introduce boolean type for gitlab_extra_settings

### DIFF
--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -93,7 +93,9 @@ registry_nginx['ssl_certificate_key'] = "{{ gitlab_registry_nginx_ssl_certificat
 {% for extra in gitlab_extra_settings %}
 {% for setting in extra %}
 {% for kv in extra[setting] %}
-{% if (kv.type is defined and kv.type == 'plain') or (kv.value is not string) %}
+{% if (kv.type is defined and kv.type == 'boolean') %}
+{{ setting }}['{{ kv.key }}'] = {{ kv.value | lower }}
+{% elif (kv.type is defined and kv.type == 'plain') or (kv.value is not string) %}
 {{ setting }}['{{ kv.key }}'] = {{ kv.value }}
 {% else %}
 {{ setting }}['{{ kv.key }}'] = '{{ kv.value }}'


### PR DESCRIPTION
This pull request adds a new boolean type for values in `gitlab_extra_settings` so that they are added lower-case to `gitlab.rb` template.

Fixes geerlingguy/ansible-role-gitlab#154