### PR TITLE
Fix conditional for registry check

### DIFF
--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -82,7 +82,7 @@ nginx['ssl_client_certificate'] = "{{ gitlab_nginx_ssl_client_certificate }}"
 
 # GitLab registry.
 registry['enable'] = {{ gitlab_registry_enable }}
-{% if gitlab_registry_enable %}
+{% if gitlab_registry_enable == "true" %}
 registry_external_url "{{ gitlab_registry_external_url }}"
 registry_nginx['ssl_certificate'] = "{{ gitlab_registry_nginx_ssl_certificate }}"
 registry_nginx['ssl_certificate_key'] = "{{ gitlab_registry_nginx_ssl_certificate_key }}"


### PR DESCRIPTION
As with other booleans these are string true/false and therefore need to check against string true (see various other examples in the same file)