### PR TITLE
Added ability to upgrade using the same role

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,12 +14,12 @@
 - name: Install GitLab dependencies.
   package:
     name: "{{ gitlab_dependencies }}"
-    state: present
+    state: latest
 
 - name: Install GitLab dependencies (Debian).
   apt:
     name: gnupg2
-    state: present
+    state: latest
   when: ansible_os_family == 'Debian'
 
 - name: Download GitLab repository installation script.
@@ -42,10 +42,9 @@
 - name: Install GitLab
   package:
     name: "{{ gitlab_package_name | default(gitlab_edition) }}"
-    state: present
-  async: 300
+    state: latest
+  async: 3000
   poll: 5
-  when: not gitlab_file.stat.exists
 
 # Start and configure GitLab. Sometimes the first run fails, but after that,
 # restarts fix problems, so ignore failures on this run.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,12 +39,21 @@
     gitlab_package_name: "{{ gitlab_edition }}{{ gitlab_package_version_separator }}{{ gitlab_version }}"
   when: gitlab_version | default(false)
 
-- name: Install GitLab
+- name: Install GitLab specific version
   package:
-    name: "{{ gitlab_package_name | default(gitlab_edition) }}"
+    name: "{{ gitlab_package_name }}"
+    state: present
+  async: 3000
+  poll: 5
+  when: (gitlab_version is defined) and (gitlab_version|length > 0)
+
+- name: Install GitLab latest version
+  package:
+    name: "{{ gitlab_edition }}"
     state: latest
   async: 3000
   poll: 5
+  when: (gitlab_version is not defined) or (gitlab_version|length == 0)
 
 # Start and configure GitLab. Sometimes the first run fails, but after that,
 # restarts fix problems, so ignore failures on this run.


### PR DESCRIPTION
For upgrade process we need to have ability to trigger again this role and gitlab should be updated.
For the moment it doesn't work, there are workaround for that (remove file /usr/bin/gitlab-ctl before triggering ansible playbook)
In this PR i've fixed it.

Also created some manual test with Vagrant here: [test_gitlab_upgrade](https://github.com/DmitriyStoyanov/test_gitlab_upgrade) and all looks fine.

If variable gitlab_version is set up, than it will try to install package with some specific version, if not it will use latest available version. But if for example installed 11.10.8 version it will fail with update to 13.1.4 version and show such info in ansible log.

For upgrade to the latest gitlab version need to use some [gitlab upgrade path](https://docs.gitlab.com/ee/policy/maintenance.html#upgrade-recommendations)

and i've created this stuff here: [bootstrap.sh](https://github.com/DmitriyStoyanov/test_gitlab_upgrade/blob/master/bootstrap.sh#L26)
with upgrade 
```gitlab_install 11.10.8-ce.0
gitlab_install 11.11.8-ce.0
gitlab_install 12.0.12-ce.0
gitlab_install 12.5.7-ce.0
gitlab_install 12.10.11-ce.0
gitlab_install 13.0.6-ce.0
gitlab_install
```

My test finished without issues.

Points to improve:
- I guess also better to implement verifying migration workers count before upgrade gitlab in ansible as i've created here  [bootstrap.sh](https://github.com/DmitriyStoyanov/test_gitlab_upgrade/blob/master/bootstrap.sh#L10)
- move gitlab version to something like 12.10.11 instead of 12.10.11-ce.0 and adding suffix inside of ansible role
