### PR TITLE
Increased async for gitlab package install

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,7 +43,7 @@
   package:
     name: "{{ gitlab_package_name | default(gitlab_edition) }}"
     state: present
-  async: 300
+  async: 600
   poll: 5
   when: not gitlab_file.stat.exists
 


### PR DESCRIPTION
Tested the async value of 300 on AWS and it fails consistently, manual install of the gitlab-ce package tells me that 600 should be a good value, no failures when testing, consistently succeedes now.

Note, it's a huge package and it does a lot of post stuff.