### PR TITLE
Add option for setting gitlab.rb options before first configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ If you'd like to install a specific version, set the version here (e.g. `11.4.0-
 
 The `gitlab.rb.j2` template packaged with this role is meant to be very generic and serve a variety of use cases. However, many people would like to have a much more customized version, and so you can override this role's default template with your own, adding any additional customizations you need. To do this:
 
-  - Create a `templates` directory at the same level as your playbook.
-  - Create a `templates\mygitlab.rb.j2` file (just choose a different name from the default template).
-  - Set the variable like: `gitlab_config_template: mygitlab.rb.j2` (with the name of your custom template).
+- Create a `templates` directory at the same level as your playbook.
+- Create a `templates\mygitlab.rb.j2` file (just choose a different name from the default template).
+- Set the variable like: `gitlab_config_template: mygitlab.rb.j2` (with the name of your custom template).
 
-### SSL Configuration.
+### SSL Configuration
 
     gitlab_redirect_http_to_https: "true"
     gitlab_ssl_certificate: "/etc/gitlab/ssl/{{ gitlab_domain }}.crt"

--- a/README.md
+++ b/README.md
@@ -154,6 +154,16 @@ GitLab includes a number of themes, and you can set the default for all users wi
 
 Gitlab have many other settings ([see official documentation](https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/files/gitlab-config-template/gitlab.rb.template)), and you can add them with this special variable `gitlab_extra_settings` with the concerned setting and the `key` and `value` keywords.
 
+In case you need to set some settings before reconfiguring GitLab for the first time (e.g. setting initial Runner Token), set them in `gitlab_preconfig_settings`:
+
+    gitlab_preconfig_settings:
+        - setting: "gitlab_rails['initial_shared_runners_registration_token']"
+            value: "..."
+
+This will result in the following configuration line:
+
+    gitlab_rails['initial_shared_runners_registration_token'] = '...'
+
 ## Dependencies
 
 None.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,6 +47,14 @@
   poll: 5
   when: not gitlab_file.stat.exists
 
+- name: Setting options before configuring GitLab
+  lineinfile:
+    path: /etc/gitlab/gitlab.rb
+    regexp: "^{{ item.setting }}="
+    line: "{{ item.setting }} = '{{ item.value }}'"
+  loop: "{{ gitlab_preconfig_settings }}"
+  when: gitlab_preconfig_settings
+
 # Start and configure GitLab. Sometimes the first run fails, but after that,
 # restarts fix problems, so ignore failures on this run.
 - name: Reconfigure GitLab (first run).

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,7 +53,7 @@
     regexp: "^{{ item.setting }}="
     line: "{{ item.setting }} = '{{ item.value }}'"
   loop: "{{ gitlab_preconfig_settings }}"
-  when: gitlab_preconfig_settings
+  when: gitlab_preconfig_settings | bool
 
 # Start and configure GitLab. Sometimes the first run fails, but after that,
 # restarts fix problems, so ignore failures on this run.


### PR DESCRIPTION
Sometimes it is necessary to set options in `/etc/gitlab/gitlab.rb` before running the first configuration (*e.g. setting the initial runner token*).

This PR adds an optional variable `gitlab_preconfig_settings` for this. Values in this list will be added via `lineinfile` before running the initial configuration.

See also issue #166 for more details.