### PR TITLE
Use double quotes for strings in custom settings instead of single.

### DIFF
--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -94,9 +94,9 @@ registry_nginx['ssl_certificate_key'] = "{{ gitlab_registry_nginx_ssl_certificat
 {% for setting in extra %}
 {% for kv in extra[setting] %}
 {% if (kv.type is defined and kv.type == 'plain') or (kv.value is not string) %}
-{{ setting }}['{{ kv.key }}'] = {{ kv.value }}
+{{ setting }}['{{ kv.key }}'] = {{ kv.value | to_json }}
 {% else %}
-{{ setting }}['{{ kv.key }}'] = '{{ kv.value }}'
+{{ setting }}['{{ kv.key }}'] = "{{ kv.value }}"
 {% endif %}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
Single quotes prevent the insertion of newlines into strings in the config files due to Ruby's string rules. E.g., `"a\nb" ` results in `a` and `b` separated by a newline character. `'a\nb'` results in a string of length four consisting of `a`, a backslash, `n, and `b`.

Changing the quotes used in the template allows us to insert strings with newline characters but may break old scripts relying on the strings being treated as raw.

The reason for this PR is that it's not possible to add a new line in a string with single quotes and new lines are necessary for some settings. Specifically, `gitlab_rails['omniauth_providers']` with SAML and certificates only accepts certificates conformant to RFC 1421 which require the use of newlines.

Since JSON requires that strings be double-quoted, `to_json` has the effect of forcing Jinja to render strings with double quotes whilst the string literals on line 99 are simply double-quoted.