### PR TITLE
Fix broken gitlab_restart_handler_failed_when expression

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,8 +45,8 @@ gitlab_smtp_ca_file: "/etc/ssl/certs/ca-certificates.crt"
 gitlab_nginx_ssl_verify_client: ""
 gitlab_nginx_ssl_client_certificate: ""
 
-# Probably best to leave this as the default, unless doing testing.
-gitlab_restart_handler_failed_when: 'gitlab_restart.rc != 0'
+# Ignore errors during gitlab restart - can be turned on for testing
+gitlab_restart_handler_ignore_failure: false
 
 # Dependencies.
 gitlab_dependencies:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,4 +2,6 @@
 - name: restart gitlab
   command: gitlab-ctl reconfigure
   register: gitlab_restart
-  failed_when: gitlab_restart_handler_failed_when | bool
+  failed_when:
+    - gitlab_restart.rc != 0
+    - gitlab_restart_handler_ignore_failure == false

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,7 +4,7 @@
   become: true
 
   vars:
-    gitlab_restart_handler_failed_when: false
+    gitlab_restart_handler_ignore_failure: true
 
   pre_tasks:
     - name: Update apt cache.

--- a/molecule/default/version.yml
+++ b/molecule/default/version.yml
@@ -4,7 +4,7 @@
   become: true
 
   vars:
-    gitlab_restart_handler_failed_when: false
+    gitlab_restart_handler_ignore_failure: true
 
   pre_tasks:
     - name: Update apt cache.


### PR DESCRIPTION
The 'restart gitlab' handler never reports failures even if the `gitlab-ctl reconfigure` command returned a non-zero exit code. This change should fix the `failed_when` expression and still allow disabling the check for testing purposes.