### PR TITLE
Fixes for letsencrypt definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Whether to create a self-signed certificate for serving GitLab over a secure con
 
 ### LetsEncrypt Configuration.
 
-    gitlab_letsencrypt_enable: "false"
+    gitlab_letsencrypt_enable: false
     gitlab_letsencrypt_contact_emails: ["gitlab@example.com"]
     gitlab_letsencrypt_auto_renew_hour: 1
     gitlab_letsencrypt_auto_renew_minute: 30

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -75,7 +75,7 @@ gitlab_registry_nginx_ssl_certificate: "/etc/gitlab/ssl/gitlab.crt"
 gitlab_registry_nginx_ssl_certificate_key: "/etc/gitlab/ssl/gitlab.key"
 
 # LetsEncrypt configuration.
-gitlab_letsencrypt_enable: "false"
+gitlab_letsencrypt_enable: false
 gitlab_letsencrypt_contact_emails: ["gitlab@example.com"]
 gitlab_letsencrypt_auto_renew_hour: 1
 gitlab_letsencrypt_auto_renew_minute: 30

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,7 +76,7 @@ gitlab_registry_nginx_ssl_certificate_key: "/etc/gitlab/ssl/gitlab.key"
 
 # LetsEncrypt configuration.
 gitlab_letsencrypt_enable: false
-gitlab_letsencrypt_contact_emails: ["gitlab@example.com"]
+gitlab_letsencrypt_contact_emails: ["gitlab@example.com", "watcher@example.com"]
 gitlab_letsencrypt_auto_renew_hour: 1
 gitlab_letsencrypt_auto_renew_minute: 30
 gitlab_letsencrypt_auto_renew_day_of_month: "*/7"

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -21,7 +21,7 @@ nginx['ssl_certificate_key'] = "{{ gitlab_ssl_certificate_key }}"
 
 {% if gitlab_letsencrypt_enable %}
 letsencrypt['enable'] = true
-letsencrypt['contact_emails'] = "{{ gitlab_letsencrypt_contact_emails | to_json }}"
+letsencrypt['contact_emails'] = '{{ gitlab_letsencrypt_contact_emails | to_json }}'
 letsencrypt['auto_renew_hour'] = "{{ gitlab_letsencrypt_auto_renew_hour }}"
 letsencrypt['auto_renew_minute'] = "{{ gitlab_letsencrypt_auto_renew_minute }}"
 letsencrypt['auto_renew_day_of_month'] = "{{ gitlab_letsencrypt_auto_renew_day_of_month }}"

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -19,14 +19,16 @@ nginx['redirect_http_to_https'] = {{ gitlab_redirect_http_to_https }}
 nginx['ssl_certificate'] = "{{ gitlab_ssl_certificate }}"
 nginx['ssl_certificate_key'] = "{{ gitlab_ssl_certificate_key }}"
 
-letsencrypt['enable'] = "{{ gitlab_letsencrypt_enable }}"
 {% if gitlab_letsencrypt_enable %}
+letsencrypt['enable'] = true
 letsencrypt['contact_emails'] = "{{ gitlab_letsencrypt_contact_emails | to_json }}"
 letsencrypt['auto_renew_hour'] = "{{ gitlab_letsencrypt_auto_renew_hour }}"
 letsencrypt['auto_renew_minute'] = "{{ gitlab_letsencrypt_auto_renew_minute }}"
 letsencrypt['auto_renew_day_of_month'] = "{{ gitlab_letsencrypt_auto_renew_day_of_month }}"
 letsencrypt['auto_renew'] = "{{ gitlab_letsencrypt_auto_renew }}"
-{% endif %}
+{% else %}
+letsencrypt['enable'] = false
+{% endif %}{# if gitlab_letsencrypt_enable #}
 
 # The directory where Git repositories will be stored.
 git_data_dirs({"default" => {"path" => "{{ gitlab_git_data_dir }}"} })


### PR DESCRIPTION
Some definitions from letsencrypt was wrong so disable it was not possible.
Also contact_emals definition was not working correctly
