### PR TITLE
Only set letsencrypt options when 'gitlab_letsencrypt_enable' is 'true'

### DIFF
--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -20,7 +20,7 @@ nginx['ssl_certificate'] = "{{ gitlab_ssl_certificate }}"
 nginx['ssl_certificate_key'] = "{{ gitlab_ssl_certificate_key }}"
 
 letsencrypt['enable'] = "{{ gitlab_letsencrypt_enable }}"
-{% if gitlab_letsencrypt_enable %}
+{% if gitlab_letsencrypt_enable == "true" %}
 letsencrypt['contact_emails'] = "{{ gitlab_letsencrypt_contact_emails | to_json }}"
 letsencrypt['auto_renew_hour'] = "{{ gitlab_letsencrypt_auto_renew_hour }}"
 letsencrypt['auto_renew_minute'] = "{{ gitlab_letsencrypt_auto_renew_minute }}"


### PR DESCRIPTION
Currently, letsencrypt options are always set, as the check only verifies that the variable is set.

Now we only set further variables when the 'gitlab_letsencrypt_enable' variable is set to 'true'.