### PR TITLE
letsencrypt config fixes

### DIFF
--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -19,8 +19,8 @@ nginx['redirect_http_to_https'] = {{ gitlab_redirect_http_to_https }}
 nginx['ssl_certificate'] = "{{ gitlab_ssl_certificate }}"
 nginx['ssl_certificate_key'] = "{{ gitlab_ssl_certificate_key }}"
 
-letsencrypt['enable'] = "{{ gitlab_letsencrypt_enable }}"
-{% if gitlab_letsencrypt_enable %}
+letsencrypt['enable'] = {{ gitlab_letsencrypt_enable }}
+{% if gitlab_letsencrypt_enable == "true" %}
 letsencrypt['contact_emails'] = "{{ gitlab_letsencrypt_contact_emails | to_json }}"
 letsencrypt['auto_renew_hour'] = "{{ gitlab_letsencrypt_auto_renew_hour }}"
 letsencrypt['auto_renew_minute'] = "{{ gitlab_letsencrypt_auto_renew_minute }}"


### PR DESCRIPTION
letsencrypt behaves enabled even if "gitlab_letsencrypt_enable" is set 
to false. gitlab-ctl reconfigure seems to ignore the variable with 
quotation marks and uses the default "true"