### PR TITLE
Update gitlab.rb.j2

### DIFF
--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -21,7 +21,7 @@ nginx['ssl_certificate_key'] = "{{ gitlab_ssl_certificate_key }}"
 
 letsencrypt['enable'] = "{{ gitlab_letsencrypt_enable }}"
 {% if gitlab_letsencrypt_enable %}
-letsencrypt['contact_emails'] = "{{ gitlab_letsencrypt_contact_emails | to_json }}"
+letsencrypt['contact_emails'] = {{ gitlab_letsencrypt_contact_emails | to_json }}
 letsencrypt['auto_renew_hour'] = "{{ gitlab_letsencrypt_auto_renew_hour }}"
 letsencrypt['auto_renew_minute'] = "{{ gitlab_letsencrypt_auto_renew_minute }}"
 letsencrypt['auto_renew_day_of_month'] = "{{ gitlab_letsencrypt_auto_renew_day_of_month }}"


### PR DESCRIPTION
The gitlab contact_emails shouldn't have quotes around them, the default for this contains quotes (and I assume any replacement by users should as well) and the double sets breaks the config.