### PR TITLE
Add the possibility to use initial_shared_runner_token and intial_roo…

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,6 +47,14 @@
   poll: 5
   when: not gitlab_file.stat.exists
 
+- name: Copy GitLab configuration file.
+  template:
+    src: "{{ gitlab_config_template }}"
+    dest: /etc/gitlab/gitlab.rb
+    owner: root
+    group: root
+    mode: 0600
+
 # Start and configure GitLab. Sometimes the first run fails, but after that,
 # restarts fix problems, so ignore failures on this run.
 - name: Reconfigure GitLab (first run).
@@ -70,12 +78,3 @@
     -days 3650 -keyout {{ gitlab_ssl_certificate_key }} -out {{ gitlab_ssl_certificate }} -extensions v3_ca
     creates={{ gitlab_ssl_certificate }}
   when: gitlab_create_self_signed_cert
-
-- name: Copy GitLab configuration file.
-  template:
-    src: "{{ gitlab_config_template }}"
-    dest: /etc/gitlab/gitlab.rb
-    owner: root
-    group: root
-    mode: 0600
-  notify: restart gitlab


### PR DESCRIPTION
…t_password

https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/files/gitlab-config-template/gitlab.rb.template#L669-670

Change the initial default admin password and shared runner registration
tokens is only applicable on initial setup, changing these settings after
database is created and seeded won't yield any change.