### PR TITLE
Add ldap user filter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,23 @@ Whether to create a self-signed certificate for serving GitLab over a secure con
 
 GitLab LetsEncrypt configuration; tells GitLab whether to request and use a certificate from LetsEncrypt, if `gitlab_letsencrypt_enable` is set to `true`. Multiple contact emails can be configured under `gitlab_letsencrypt_contact_emails` as a list.
 
+### Container Registry
+
+
+    gitlab_registry_enable: false
+    gitlab_registry_path: "/var/opt/gitlab/gitlab-rails/shared/registry"
+    gitlab_registry_external_url: "https://gitlab.example.com:4567"
+    gitlab_registry_nginx_ssl_certificate: "/etc/gitlab/ssl/{{ gitlab_domain }}.crt"
+    gitlab_registry_nginx_ssl_certificate_key: "/etc/gitlab/ssl/{{ gitlab_domain }}.key"
+
+
+
+There are two ways you can configure the Registry’s external domain. Either:
+
+Use the existing GitLab domain. The Registry listens on a port and reuses the TLS certificate from GitLab.
+Use a completely separate domain with a new TLS certificate for that domain.
+
+
     # LDAP Configuration.
     gitlab_ldap_enabled: false
     gitlab_ldap_host: "example.com"

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ GitLab LetsEncrypt configuration; tells GitLab whether to request and use a cert
     gitlab_ldap_bind_dn: "CN=Username,CN=Users,DC=example,DC=com"
     gitlab_ldap_password: "password"
     gitlab_ldap_base: "DC=example,DC=com"
+    gitlab_ldap_user_filter: "(givenName=John)"
 
 GitLab LDAP configuration; if `gitlab_ldap_enabled` is `true`, the rest of the configuration will tell GitLab how to connect to an LDAP server for centralized authentication.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,7 @@ gitlab_ldap_method: "plain"
 gitlab_ldap_bind_dn: "CN=Username,CN=Users,DC=example,DC=com"
 gitlab_ldap_password: "password"
 gitlab_ldap_base: "DC=example,DC=com"
+gitlab_ldap_user_filter: ""
 
 # SMTP Configuration
 gitlab_smtp_enable: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -71,9 +71,10 @@ gitlab_email_reply_to: "gitlab@example.com"
 
 # Registry configuration.
 gitlab_registry_enable: false
+gitlab_registry_path: "/var/opt/gitlab/gitlab-rails/shared/registry"
 gitlab_registry_external_url: "https://gitlab.example.com:4567"
-gitlab_registry_nginx_ssl_certificate: "/etc/gitlab/ssl/gitlab.crt"
-gitlab_registry_nginx_ssl_certificate_key: "/etc/gitlab/ssl/gitlab.key"
+gitlab_registry_nginx_ssl_certificate: "/etc/gitlab/ssl/{{ gitlab_domain }}.crt"
+gitlab_registry_nginx_ssl_certificate_key: "/etc/gitlab/ssl/{{ gitlab_domain }}.key"
 
 # LetsEncrypt configuration.
 gitlab_letsencrypt_enable: false

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -46,6 +46,7 @@ gitlab_rails['ldap_bind_dn'] = '{{ gitlab_ldap_bind_dn }}'
 gitlab_rails['ldap_password'] = '{{ gitlab_ldap_password }}'
 gitlab_rails['ldap_allow_username_or_email_login'] = true
 gitlab_rails['ldap_base'] = '{{ gitlab_ldap_base }}'
+gitlab_rails['ldap_user_filter'] = '{{ gitlab_ldap_user_filter }}'
 {% endif %}
 
 # GitLab Nginx

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -93,10 +93,13 @@ nginx['ssl_client_certificate'] = "{{ gitlab_nginx_ssl_client_certificate }}"
 # GitLab registry.
 registry['enable'] = {{ gitlab_registry_enable | lower }}
 {% if gitlab_registry_enable %}
+gitlab_rails['registry_path'] = "{{ gitlab_registry_path }}"
 registry_external_url "{{ gitlab_registry_external_url }}"
 registry_nginx['ssl_certificate'] = "{{ gitlab_registry_nginx_ssl_certificate }}"
 registry_nginx['ssl_certificate_key'] = "{{ gitlab_registry_nginx_ssl_certificate_key }}"
 {% endif %}
+
+#
 
 {% if gitlab_extra_settings is defined %}
 # Extra configuration


### PR DESCRIPTION
Being tasked to deploy self-hosted Gitlab instance for my faculty to use and enabling ldap signin, I have faced complications. The ldap server is for the whole university, so students from different faculties (under the university) had access to gitlab. By introducing a user filter option, i could easily filter out right students. 