### PR TITLE
Allow for known ruby deprecation warnings

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,8 +46,8 @@ gitlab_nginx_ssl_verify_client: ""
 gitlab_nginx_ssl_client_certificate: ""
 
 # Probably best to leave this as the default, unless doing testing.
-gitlab_restart_handler_failed_when: (gitlab_restart.rc != 0) or
-  (None in (gitlab_restart.stderr_lines | default([]) | map('regex_search', 'URI\.(?:un)?escape is obsolete')))
+gitlab_restart_handler_failed_when: "{{ (gitlab_restart.rc != 0) or
+  (None in (gitlab_restart.stderr_lines | default([]) | map('regex_search', 'URI\\.(?:un)?escape is obsolete'))) }}"
 
 # Dependencies.
 gitlab_dependencies:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,7 +46,8 @@ gitlab_nginx_ssl_verify_client: ""
 gitlab_nginx_ssl_client_certificate: ""
 
 # Probably best to leave this as the default, unless doing testing.
-gitlab_restart_handler_failed_when: 'gitlab_restart.rc != 0'
+gitlab_restart_handler_failed_when: (gitlab_restart.rc != 0) or
+  (None in (gitlab_restart.stderr_lines | default([]) | map('regex_search', 'URI\.(?:un)?escape is obsolete')))
 
 # Dependencies.
 gitlab_dependencies:


### PR DESCRIPTION
Allow for known ruby deprecation warnings

Update gitlab_restart_handler_failed_when var to allow for known ruby deprecation warnings
Addresses issue: https://github.com/geerlingguy/ansible-role-gitlab/issues/197