### PR TITLE
Allow install of gitlab from other release' apt source

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ The `gitlab.rb.j2` template packaged with this role is meant to be very generic 
   - Create a `templates\mygitlab.rb.j2` file (just choose a different name from the default template).
   - Set the variable like: `gitlab_config_template: mygitlab.rb.j2` (with the name of your custom template).
 
+Sometimes the package repositiories for gitlab lag way behind the release of a new distribution. In such cases the solution is often to use the package repository for the previous distribution release. For Debian based distributions the distribution release can be overridden with (for example):
+
+  override_distribution_release: focal
+
 ### SSL Configuration.
 
     gitlab_redirect_http_to_https: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -84,7 +84,7 @@
 - name: Create self-signed certificate.
   command: >
     openssl req -new -nodes -x509 -subj "{{ gitlab_self_signed_cert_subj }}"
-    -days 3650 -keyout {{ gitlab_ssl_certificate_key }} -out {{ gitlab_ssl_certificate }} -extensions v3_ca
+    -days 3650 -keyout {{ gitlab_ssl_certificate_key }} -out {{ gitlab_ssl_certificate }} -extensions v3_ca -addext subjectAltName=IP:{{ansible_default_ipv4.address}}
     creates={{ gitlab_ssl_certificate }}
   when: gitlab_create_self_signed_cert
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,6 +34,22 @@
   register: output
   when: not gitlab_file.stat.exists
 
+- name: Stat sources file
+  stat:
+    path: "/etc/apt/sources.list.d/gitlab_{{gitlab_edition}}.list"
+  register: sources_file
+
+- name: Replace distribution name in apt source when gitlab package repo lags behind
+  ansible.builtin.replace:
+    path: "/etc/apt/sources.list.d/gitlab_{{gitlab_edition}}.list"
+    regexp: "{{ ansible_distribution_release }}"
+    replace: "{{ override_distribution_release }}"
+  when:
+    - override_distribution_release is defined
+    - ansible_os_family == 'Debian'
+    - sources_file.stat.exists
+    - not gitlab_file.stat.exists
+
 - name: Define the Gitlab package name.
   set_fact:
     gitlab_package_name: "{{ gitlab_edition }}{{ gitlab_package_version_separator }}{{ gitlab_version }}"
@@ -43,6 +59,7 @@
   package:
     name: "{{ gitlab_package_name | default(gitlab_edition) }}"
     state: present
+    update_cache: true
   async: 300
   poll: 5
   when: not gitlab_file.stat.exists


### PR DESCRIPTION
Discovered this when trying to install gitlab on Ubuntu Jammy (22.04). See also https://gitlab.com/gitlab-org/gitlab/-/issues/364673 . Tested with Gitlab from Focal (20.04) on Jammy (22.04)