### PR TITLE
Use new ldap configuration method

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ GitLab LetsEncrypt configuration; tells GitLab whether to request and use a cert
     gitlab_ldap_password: "password"
     gitlab_ldap_base: "DC=example,DC=com"
 
-GitLab LDAP configuration; if `gitlab_ldap_enabled` is `true`, the rest of the configuration will tell GitLab how to connect to an LDAP server for centralized authentication.
+GitLab LDAP configuration; if `gitlab_ldap_enabled` is `true`, the rest of the configuration will tell GitLab how to connect to an LDAP server for centralized authentication. gitlab_ldap_method is one of 'start_tls', 'simple_tls', or 'plain' (usually, you want simple_tls): see https://docs.gitlab.com/ee/administration/auth/ldap/ for full gitlab documentation.
 
     gitlab_dependencies:
       - openssh-server

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -38,14 +38,19 @@ gitlab_rails['backup_path'] = "{{ gitlab_backup_path }}"
 # https://gitlab.com/gitlab-org/gitlab-ce/blob/master/config/gitlab.yml.example#L118
 gitlab_rails['ldap_enabled'] = {{ gitlab_ldap_enabled | lower }}
 {% if gitlab_ldap_enabled %}
-gitlab_rails['ldap_host'] = '{{ gitlab_ldap_host }}'
-gitlab_rails['ldap_port'] = {{ gitlab_ldap_port }}
-gitlab_rails['ldap_uid'] = '{{ gitlab_ldap_uid }}'
-gitlab_rails['ldap_method'] = '{{ gitlab_ldap_method}}' # 'ssl' or 'plain'
-gitlab_rails['ldap_bind_dn'] = '{{ gitlab_ldap_bind_dn }}'
-gitlab_rails['ldap_password'] = '{{ gitlab_ldap_password }}'
-gitlab_rails['ldap_allow_username_or_email_login'] = true
-gitlab_rails['ldap_base'] = '{{ gitlab_ldap_base }}'
+gitlab_rails['ldap_servers'] = {
+  'main' => {
+    'label' => 'LDAP',
+    'host' =>  '{{ gitlab_ldap_host }}',
+    'port' => {{ gitlab_ldap_port }},
+    'uid' => '{{ gitlab_ldap_uid }}',
+    'encryption' => '{{ gitlab_ldap_method}}',
+    'bind_dn' => '{{ gitlab_ldap_bind_dn }}',
+    'password' => '{{ gitlab_ldap_password }}',
+    'allow_username_or_email_login' => true,
+    'base' => '{{ gitlab_ldap_base }}'
+  }
+}
 {% endif %}
 
 # GitLab Nginx


### PR DESCRIPTION
Use new configuration method for LDAP.

The ldap_servers format is introduced in gitlab 14.7 and mandatory since gitlab 16.2 (released 3 days ago). Gitlab 16.2 won't work with old configuration.

Format is described in https://docs.gitlab.com/ee/administration/auth/ldap/

There are a few configuration settings not handle by this template, I just manage to set existing LDAP variables.